### PR TITLE
Add builder for custom docker image to workflows

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,0 +1,11 @@
+# An image derived from ledger-app-builder but also containing the bitcoin-core binaries
+
+FROM ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest
+
+# download bitcoin-core and decompress it to /bitcoin
+RUN curl -o /tmp/bitcoin.tar.gz https://bitcoin.org/bin/bitcoin-core-22.0/bitcoin-22.0-x86_64-linux-gnu.tar.gz && \
+    tar -xf /tmp/bitcoin.tar.gz -C / && \
+    mv /bitcoin-22.0 /bitcoin
+
+# Add bitcoin binaries to path
+ENV PATH=/bitcoin/bin:$PATH

--- a/.github/workflows/builder-image-workflow.yml
+++ b/.github/workflows/builder-image-workflow.yml
@@ -1,0 +1,32 @@
+name: Build custom ledger-app-builder-bitcoin image
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+    paths:
+      - .github/workflows/builder-image-workflow.yml
+      - .github/workflows/Dockerfile
+
+jobs:
+  build:
+    name: Build and push ledger-app-builder image
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+    - name: Clone
+      uses: actions/checkout@v2
+
+    - name: Build and push ledger-app-builder-bitcoin to GitHub Packages
+      uses: docker/build-push-action@v1
+      with:
+        dockerfile: .github/workflows/Dockerfile
+        repository: ledgerhq/app-bitcoin-new/ledger-app-builder-bitcoin
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        tag_with_sha: true
+        tags: latest


### PR DESCRIPTION
Adds an image derived from ledger-app-builder that also contains the bitcoin-core binary.
Will be useful for integration tests.  