### PR TITLE
Performance optimizations

### DIFF
--- a/src/common/wallet.h
+++ b/src/common/wallet.h
@@ -300,6 +300,8 @@ typedef struct {
 
     // common between V1 and V2
     int16_t key_index;  // index of the key
+    int16_t
+        placeholder_index;  // index of the placeholder in the descriptor template, in parsing order
 } policy_node_key_placeholder_t;
 
 DEFINE_REL_PTR(policy_node_key_placeholder, policy_node_key_placeholder_t)

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -158,6 +158,8 @@ int bip32_CKDpub(const serialized_extended_pubkey_t *parent,
     {  // make sure that heavy memory allocations are freed as soon as possible
         // compute point(I_L)
         uint8_t P[65];
+        // as the arguments of bip32_CKDpub are public keys, we do not need to use math functions
+        // hardened against side channels attacks, which are slower
         if (0 > secp256k1_point_unsafe(I_L, P)) return -1;
 
         uint8_t K_par[65];
@@ -575,6 +577,8 @@ int crypto_tr_tweak_pubkey(const uint8_t pubkey[static 32],
         return -1;
     }
 
+    // as the arguments of bip32_CKDpub are public keys, we do not need to use math functions
+    // hardened against side channels attacks, which are slower
     if (0 > secp256k1_point_unsafe(t, Q)) {
         // point at infinity, or error
         return -1;

--- a/src/handler/lib/policy.c
+++ b/src/handler/lib/policy.c
@@ -469,10 +469,16 @@ __attribute__((warn_unused_result)) static int get_derived_pubkey(
 
     // we derive the /<change>/<address_index> child of this pubkey
     // we reuse the same memory of ext_pubkey
-    bip32_CKDpub(&ext_pubkey,
-                 wdi->change ? key_placeholder->num_second : key_placeholder->num_first,
-                 &ext_pubkey);
-    bip32_CKDpub(&ext_pubkey, wdi->address_index, &ext_pubkey);
+    if (0 > derive_first_step_for_pubkey(&ext_pubkey,
+                                         key_placeholder,
+                                         wdi->sign_psbt_cache,
+                                         wdi->change,
+                                         &ext_pubkey)) {
+        return -1;
+    }
+    if (0 > bip32_CKDpub(&ext_pubkey, wdi->address_index, &ext_pubkey)) {
+        return -1;
+    }
 
     memcpy(out, ext_pubkey.compressed_pubkey, 33);
 

--- a/src/handler/lib/policy.h
+++ b/src/handler/lib/policy.h
@@ -2,6 +2,7 @@
 
 #include "../../boilerplate/dispatcher.h"
 #include "../../common/wallet.h"
+#include "../../handler/sign_psbt/sign_psbt_cache.h"
 
 /**
  * Parses a serialized wallet policy, saving the wallet header, the policy map descriptor and the
@@ -48,6 +49,8 @@ typedef struct {
     uint32_t n_keys;        // The number of key information placeholders in the policy
     size_t address_index;   // The address index to use in the derivation
     bool change;            // whether a change address or a receive address is derived
+    sign_psbt_cache_t
+        *sign_psbt_cache;  // If not NULL, the cache for key derivations used during signing
 } wallet_derivation_info_t;
 
 /**

--- a/src/handler/sign_psbt/compare_wallet_script_at_path.c
+++ b/src/handler/sign_psbt/compare_wallet_script_at_path.c
@@ -9,6 +9,7 @@
 #include "../../common/read.h"
 
 int compare_wallet_script_at_path(dispatcher_context_t *dispatcher_context,
+                                  sign_psbt_cache_t *sign_psbt_cache,
                                   uint32_t change,
                                   uint32_t address_index,
                                   const policy_node_t *policy,
@@ -28,7 +29,8 @@ int compare_wallet_script_at_path(dispatcher_context_t *dispatcher_context,
                                                       .keys_merkle_root = keys_merkle_root,
                                                       .n_keys = n_keys,
                                                       .change = change,
-                                                      .address_index = address_index},
+                                                      .address_index = address_index,
+                                                      .sign_psbt_cache = sign_psbt_cache},
                           wallet_script);
     if (wallet_script_len < 0) {
         PRINTF("Failed to get wallet script\n");

--- a/src/handler/sign_psbt/compare_wallet_script_at_path.h
+++ b/src/handler/sign_psbt/compare_wallet_script_at_path.h
@@ -3,11 +3,13 @@
 #include "../../boilerplate/dispatcher.h"
 #include "../../common/merkle.h"
 #include "../../common/wallet.h"
+#include "../../handler/sign_psbt/sign_psbt_cache.h"
 
 /**
  * TODO
  */
 int compare_wallet_script_at_path(dispatcher_context_t *dispatcher_context,
+                                  sign_psbt_cache_t *sign_psbt_cache,
                                   uint32_t change,
                                   uint32_t address_index,
                                   const policy_node_t *policy,

--- a/src/handler/sign_psbt/sign_psbt_cache.c
+++ b/src/handler/sign_psbt/sign_psbt_cache.c
@@ -1,0 +1,35 @@
+#include "sign_psbt_cache.h"
+
+int derive_first_step_for_pubkey(const serialized_extended_pubkey_t *base_key,
+                                 const policy_node_key_placeholder_t *placeholder,
+                                 sign_psbt_cache_t *cache,
+                                 bool is_change,
+                                 serialized_extended_pubkey_t *out_pubkey) {
+    uint32_t change_step = is_change ? placeholder->num_second : placeholder->num_first;
+
+    // make sure a cache was provided, and the index is less than the size of the cache
+    if (placeholder->placeholder_index >= MAX_CACHED_KEY_EXPRESSIONS || !cache) {
+        // do not use the cache, derive the key directly
+        return bip32_CKDpub(base_key, change_step, out_pubkey);
+    }
+
+    if (!cache->derived_child[placeholder->placeholder_index]
+             .is_child_pubkey_initialized[is_change]) {
+        // key not in cache; compute it and store it in the cache
+        if (0 > bip32_CKDpub(
+                    base_key,
+                    change_step,
+                    &cache->derived_child[placeholder->placeholder_index].child_pubkeys[is_change]))
+            return -1;
+
+        cache->derived_child[placeholder->placeholder_index]
+            .is_child_pubkey_initialized[is_change] = true;
+    }
+
+    // now that we are guaranteed that the key is in cache, we just copy it
+    memcpy(out_pubkey,
+           &cache->derived_child[placeholder->placeholder_index].child_pubkeys[is_change],
+           sizeof(serialized_extended_pubkey_t));
+
+    return 0;
+}

--- a/src/handler/sign_psbt/sign_psbt_cache.h
+++ b/src/handler/sign_psbt/sign_psbt_cache.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "../crypto.h"
+#include "../common/wallet.h"
+
+// This allows to keep the cache size small, while only paying a performance hit for any extremely
+// complicated policy with more than 16 key expressions in total (should that occur in practice).
+#define MAX_CACHED_KEY_EXPRESSIONS 16
+
+// This structure contains all the information that is deterministically computed during the signing
+// flow, and might be accessed multiple times.
+// Currently, it only contains the derived child keys of the root keys in the key expressions of the
+// wallet policy.
+typedef struct sign_psbt_cache_s {
+    struct {
+        // 0 for the receiving address, 1 for the change address
+        bool is_child_pubkey_initialized[2];
+        serialized_extended_pubkey_t child_pubkeys[2];
+    } derived_child[MAX_CACHED_KEY_EXPRESSIONS];  // 78 * 2 * MAX_CACHED_KEY_EXPRESSIONS bytes
+} sign_psbt_cache_t;
+
+/**
+ * Initializes the sign_psbt_cache_t structure.
+ * It must be called before a sign_psbt_cache_t is used.
+ *
+ * @param[in] cache Pointer to the cache structure to be initialized.
+ */
+static inline void init_sign_psbt_cache(sign_psbt_cache_t *cache) {
+    memset(cache, 0, sizeof(sign_psbt_cache_t));
+}
+
+/*
+Public keys in a wallet policy always have two derivation steps: the first is typically 0 or 1,
+while the second step is the address index and is usually not reused in different UTXOs.
+Therefore, the inputs (and change addresses) will often share the same first step.
+By caching the intermediate pubkeys, we avoid recomputing the same BIP-32 pubkey derivations
+multiple times. This is particularly important for transactions with many inputs, as the total
+number of BIP-32 derivations is cut almost by half when using the cache.
+*/
+
+/**
+ * Derives the first step for a public key in a placeholder, using a precomputed value from the
+ * cache if available. If the key is not in the cache, it is computed and stored in the cache,
+ * unless the index is placeholder index is too large.
+ *
+ * @param[in] base_key Pointer to the base serialized extended public key.
+ * @param[in] placeholder Pointer to the policy node key placeholder, which contains derivation
+ * information.
+ * @param[in] cache Pointer to the cache structure used to store derived child keys.
+ * @param[in] is_change true if deriving the change address, false otherwise.
+ * @param[out] out_pubkey Pointer to the output serialized extended public key.
+ *
+ * @return 0 on success, -1 on failure.
+ */
+int derive_first_step_for_pubkey(const serialized_extended_pubkey_t *base_key,
+                                 const policy_node_key_placeholder_t *placeholder,
+                                 sign_psbt_cache_t *cache,
+                                 bool is_change,
+                                 serialized_extended_pubkey_t *out_pubkey);


### PR DESCRIPTION
This PR improves signing performance in two ways.

1. The total time of the pre-signing transaction checks is dominated by the `secp256k1_point`, which is used in `bip32_CKDpub` ([BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) unhardened pubkey derivation). The `cx_ecfp_scalar_mult_no_throw` function is hardened against side channels, but this has a large performance impact.
Commit ab344cdf588880ece140c33e65ca465f7f3230e1 implements the unsafe counterpart `cx_ecfp_scalar_mult_unsafe`, which is not hardened. This would be problematic in cryptographic code using secrets, but it's safe in functions that only work with public data like `bip32_CKDpub` and `crypto_tr_tweak_pubkey`.

2. All the inputs of a transaction (and change outputs, as well) spending from a [BIP-388](https://github.com/bitcoin/bips/blob/master/bip-0388.mediawiki) wallet policy have keys derived from the root keys of the policy with two derivation steps; the first is typically 0 or 1, while the second is arbitrary (the address_index). Therefore, the `root_key/0` or the `root_key/1` step ends up being derived via `bip32_CKDpub` multiple times.
Commit 711436955f3ad135daf2629dd0626c981f66cfd9 adds a cache for the result of the first derivation step, avoiding recomputing it over and over. For a transaction with a large number of inputs, this potentially cuts the number of calls to `bip32_CKDpub` by (almost) a half. Caching is only used for the first 16 key expressions in the descriptor template of the wallet policy - probably more than would ever be needed in practice. This bounds the size of the cache to about 2.5 kb of stack. It's unlikely that transactions not fitting the cache would be used in practice, but anyway the result would only be reduced performance for those extra keys, not benefiting from the cache.

Benchmarks below show the result of the improvements on the transactions from the performance test suite. All transactions have an improvement of at least 0.8s, and some very large transactions with many inputs and complex scripts have the total running time cut by over 50%.

Initial exploration suggests that significant improvements are still possible by using an implementation of `secp256k1_point_unsafe` that takes advantage that the point is fixed (the generator of the secp256k1 curve), instead of using the generic scalar multiplication. Precomputed tables and windowed scalar multiplication are probably the lower hanging fruit with the highest ROI. This is left for a future PR.

## Benchmarks
All benchmarks are executed on a Nano S+.

### Baseline
Benchmarks before the changes.

```
test_perf_sign_psbt_singlesig_wpkh[1]              5.7687 (1.0)        5.7687 (1.0)        5.7687 (1.0)      0.0000 (1.0)        5.7687 (1.0)      0.0000 (1.0)           0;0  0.1734 (1.0)           1           1
test_perf_sign_psbt_singlesig_pkh[1]               6.0501 (1.05)       6.0501 (1.05)       6.0501 (1.05)     0.0000 (1.0)        6.0501 (1.05)     0.0000 (1.0)           0;0  0.1653 (0.95)          1           1
test_perf_sign_psbt_singlesig_tr[1]                6.3956 (1.11)       6.3956 (1.11)       6.3956 (1.11)     0.0000 (1.0)        6.3956 (1.11)     0.0000 (1.0)           0;0  0.1564 (0.90)          1           1
test_perf_sign_psbt_multisig2of3_wsh[1]           10.1345 (1.76)      10.1345 (1.76)      10.1345 (1.76)     0.0000 (1.0)       10.1345 (1.76)     0.0000 (1.0)           0;0  0.0987 (0.57)          1           1
test_perf_sign_psbt_singlesig_wpkh[3]             11.4041 (1.98)      11.4041 (1.98)      11.4041 (1.98)     0.0000 (1.0)       11.4041 (1.98)     0.0000 (1.0)           0;0  0.0877 (0.51)          1           1
test_perf_sign_psbt_singlesig_tr[3]               12.5451 (2.17)      12.5451 (2.17)      12.5451 (2.17)     0.0000 (1.0)       12.5451 (2.17)     0.0000 (1.0)           0;0  0.0797 (0.46)          1           1
test_perf_sign_psbt_singlesig_pkh[3]              13.0201 (2.26)      13.0201 (2.26)      13.0201 (2.26)     0.0000 (1.0)       13.0201 (2.26)     0.0000 (1.0)           0;0  0.0768 (0.44)          1           1
test_perf_sign_psbt_tapminiscript_2paths[1]       14.7126 (2.55)      14.7126 (2.55)      14.7126 (2.55)     0.0000 (1.0)       14.7126 (2.55)     0.0000 (1.0)           0;0  0.0680 (0.39)          1           1
test_perf_sign_psbt_multisig3of5_wsh[1]           18.4035 (3.19)      18.4035 (3.19)      18.4035 (3.19)     0.0000 (1.0)       18.4035 (3.19)     0.0000 (1.0)           0;0  0.0543 (0.31)          1           1
test_perf_sign_psbt_multisig2of3_wsh[3]           20.4315 (3.54)      20.4315 (3.54)      20.4315 (3.54)     0.0000 (1.0)       20.4315 (3.54)     0.0000 (1.0)           0;0  0.0489 (0.28)          1           1
test_perf_sign_psbt_singlesig_wpkh[10]            30.6784 (5.32)      30.6784 (5.32)      30.6784 (5.32)     0.0000 (1.0)       30.6784 (5.32)     0.0000 (1.0)           0;0  0.0326 (0.19)          1           1
test_perf_sign_psbt_tapminiscript_2paths[3]       31.7105 (5.50)      31.7105 (5.50)      31.7105 (5.50)     0.0000 (1.0)       31.7105 (5.50)     0.0000 (1.0)           0;0  0.0315 (0.18)          1           1
test_perf_sign_psbt_singlesig_tr[10]              33.9459 (5.88)      33.9459 (5.88)      33.9459 (5.88)     0.0000 (1.0)       33.9459 (5.88)     0.0000 (1.0)           0;0  0.0295 (0.17)          1           1
test_perf_sign_psbt_multisig3of5_wsh[3]           36.9728 (6.41)      36.9728 (6.41)      36.9728 (6.41)     0.0000 (1.0)       36.9728 (6.41)     0.0000 (1.0)           0;0  0.0270 (0.16)          1           1
test_perf_sign_psbt_singlesig_pkh[10]             47.7810 (8.28)      47.7810 (8.28)      47.7810 (8.28)     0.0000 (1.0)       47.7810 (8.28)     0.0000 (1.0)           0;0  0.0209 (0.12)          1           1
test_perf_sign_psbt_multisig2of3_wsh[10]          56.5258 (9.80)      56.5258 (9.80)      56.5258 (9.80)     0.0000 (1.0)       56.5258 (9.80)     0.0000 (1.0)           0;0  0.0177 (0.10)          1           1
test_perf_sign_psbt_tapminiscript_2paths[10]      88.7755 (15.39)     88.7755 (15.39)     88.7755 (15.39)    0.0000 (1.0)       88.7755 (15.39)    0.0000 (1.0)           0;0  0.0113 (0.06)          1           1
test_perf_sign_psbt_multisig3of5_wsh[10]         101.9806 (17.68)    101.9806 (17.68)    101.9806 (17.68)    0.0000 (1.0)      101.9806 (17.68)    0.0000 (1.0)           0;0  0.0098 (0.06)          1           1
```

### Using `secp256k1_point_unsafe`

```
test_perf_sign_psbt_singlesig_wpkh[1]             4.8987 (1.0)       4.8987 (1.0)       4.8987 (1.0)      0.0000 (1.0)       4.8987 (1.0)      0.0000 (1.0)           0;0  0.2041 (1.0)           1           1
test_perf_sign_psbt_singlesig_pkh[1]              5.1970 (1.06)      5.1970 (1.06)      5.1970 (1.06)     0.0000 (1.0)       5.1970 (1.06)     0.0000 (1.0)           0;0  0.1924 (0.94)          1           1
test_perf_sign_psbt_singlesig_tr[1]               5.2505 (1.07)      5.2505 (1.07)      5.2505 (1.07)     0.0000 (1.0)       5.2505 (1.07)     0.0000 (1.0)           0;0  0.1905 (0.93)          1           1
test_perf_sign_psbt_multisig2of3_wsh[1]           7.3487 (1.50)      7.3487 (1.50)      7.3487 (1.50)     0.0000 (1.0)       7.3487 (1.50)     0.0000 (1.0)           0;0  0.1361 (0.67)          1           1
test_perf_sign_psbt_singlesig_wpkh[3]             9.4191 (1.92)      9.4191 (1.92)      9.4191 (1.92)     0.0000 (1.0)       9.4191 (1.92)     0.0000 (1.0)           0;0  0.1062 (0.52)          1           1
test_perf_sign_psbt_singlesig_tr[3]              10.1040 (2.06)     10.1040 (2.06)     10.1040 (2.06)     0.0000 (1.0)      10.1040 (2.06)     0.0000 (1.0)           0;0  0.0990 (0.48)          1           1
test_perf_sign_psbt_tapminiscript_2paths[1]      10.7560 (2.20)     10.7560 (2.20)     10.7560 (2.20)     0.0000 (1.0)      10.7560 (2.20)     0.0000 (1.0)           0;0  0.0930 (0.46)          1           1
test_perf_sign_psbt_singlesig_pkh[3]             11.0288 (2.25)     11.0288 (2.25)     11.0288 (2.25)     0.0000 (1.0)      11.0288 (2.25)     0.0000 (1.0)           0;0  0.0907 (0.44)          1           1
test_perf_sign_psbt_multisig3of5_wsh[1]          12.3571 (2.52)     12.3571 (2.52)     12.3571 (2.52)     0.0000 (1.0)      12.3571 (2.52)     0.0000 (1.0)           0;0  0.0809 (0.40)          1           1
test_perf_sign_psbt_multisig2of3_wsh[3]          14.6858 (3.00)     14.6858 (3.00)     14.6858 (3.00)     0.0000 (1.0)      14.6858 (3.00)     0.0000 (1.0)           0;0  0.0681 (0.33)          1           1
test_perf_sign_psbt_tapminiscript_2paths[3]      22.8977 (4.67)     22.8977 (4.67)     22.8977 (4.67)     0.0000 (1.0)      22.8977 (4.67)     0.0000 (1.0)           0;0  0.0437 (0.21)          1           1
test_perf_sign_psbt_multisig3of5_wsh[3]          24.7458 (5.05)     24.7458 (5.05)     24.7458 (5.05)     0.0000 (1.0)      24.7458 (5.05)     0.0000 (1.0)           0;0  0.0404 (0.20)          1           1
test_perf_sign_psbt_singlesig_wpkh[10]           24.8556 (5.07)     24.8556 (5.07)     24.8556 (5.07)     0.0000 (1.0)      24.8556 (5.07)     0.0000 (1.0)           0;0  0.0402 (0.20)          1           1
test_perf_sign_psbt_singlesig_tr[10]             27.0827 (5.53)     27.0827 (5.53)     27.0827 (5.53)     0.0000 (1.0)      27.0827 (5.53)     0.0000 (1.0)           0;0  0.0369 (0.18)          1           1
test_perf_sign_psbt_multisig2of3_wsh[10]         40.7628 (8.32)     40.7628 (8.32)     40.7628 (8.32)     0.0000 (1.0)      40.7628 (8.32)     0.0000 (1.0)           0;0  0.0245 (0.12)          1           1
test_perf_sign_psbt_singlesig_pkh[10]            42.1003 (8.59)     42.1003 (8.59)     42.1003 (8.59)     0.0000 (1.0)      42.1003 (8.59)     0.0000 (1.0)           0;0  0.0238 (0.12)          1           1
test_perf_sign_psbt_tapminiscript_2paths[10]     64.3309 (13.13)    64.3309 (13.13)    64.3309 (13.13)    0.0000 (1.0)      64.3309 (13.13)    0.0000 (1.0)           0;0  0.0155 (0.08)          1           1
test_perf_sign_psbt_multisig3of5_wsh[10]         67.7685 (13.83)    67.7685 (13.83)    67.7685 (13.83)    0.0000 (1.0)      67.7685 (13.83)    0.0000 (1.0)           0;0  0.0148 (0.07)          1           1
```


### Adding the cache for repeated derivations

Negligible impact for small transactions, but very substantial for transactions with many inputs.

```
test_perf_sign_psbt_singlesig_wpkh[1]             4.7133 (1.0)       4.7133 (1.0)       4.7133 (1.0)      0.0000 (1.0)       4.7133 (1.0)      0.0000 (1.0)           0;0  0.2122 (1.0)           1           1
test_perf_sign_psbt_singlesig_pkh[1]              4.8031 (1.02)      4.8031 (1.02)      4.8031 (1.02)     0.0000 (1.0)       4.8031 (1.02)     0.0000 (1.0)           0;0  0.2082 (0.98)          1           1
test_perf_sign_psbt_singlesig_tr[1]               4.9164 (1.04)      4.9164 (1.04)      4.9164 (1.04)     0.0000 (1.0)       4.9164 (1.04)     0.0000 (1.0)           0;0  0.2034 (0.96)          1           1
test_perf_sign_psbt_multisig2of3_wsh[1]           5.9457 (1.26)      5.9457 (1.26)      5.9457 (1.26)     0.0000 (1.0)       5.9457 (1.26)     0.0000 (1.0)           0;0  0.1682 (0.79)          1           1
test_perf_sign_psbt_singlesig_wpkh[3]             8.5114 (1.81)      8.5114 (1.81)      8.5114 (1.81)     0.0000 (1.0)       8.5114 (1.81)     0.0000 (1.0)           0;0  0.1175 (0.55)          1           1
test_perf_sign_psbt_tapminiscript_2paths[1]       8.9499 (1.90)      8.9499 (1.90)      8.9499 (1.90)     0.0000 (1.0)       8.9499 (1.90)     0.0000 (1.0)           0;0  0.1117 (0.53)          1           1
test_perf_sign_psbt_multisig3of5_wsh[1]           8.9516 (1.90)      8.9516 (1.90)      8.9516 (1.90)     0.0000 (1.0)       8.9516 (1.90)     0.0000 (1.0)           0;0  0.1117 (0.53)          1           1
test_perf_sign_psbt_singlesig_tr[3]               9.3474 (1.98)      9.3474 (1.98)      9.3474 (1.98)     0.0000 (1.0)       9.3474 (1.98)     0.0000 (1.0)           0;0  0.1070 (0.50)          1           1
test_perf_sign_psbt_singlesig_pkh[3]             10.3556 (2.20)     10.3556 (2.20)     10.3556 (2.20)     0.0000 (1.0)      10.3556 (2.20)     0.0000 (1.0)           0;0  0.0966 (0.46)          1           1
test_perf_sign_psbt_multisig2of3_wsh[3]          11.9158 (2.53)     11.9158 (2.53)     11.9158 (2.53)     0.0000 (1.0)      11.9158 (2.53)     0.0000 (1.0)           0;0  0.0839 (0.40)          1           1
test_perf_sign_psbt_multisig3of5_wsh[3]          17.2955 (3.67)     17.2955 (3.67)     17.2955 (3.67)     0.0000 (1.0)      17.2955 (3.67)     0.0000 (1.0)           0;0  0.0578 (0.27)          1           1
test_perf_sign_psbt_tapminiscript_2paths[3]      18.9440 (4.02)     18.9440 (4.02)     18.9440 (4.02)     0.0000 (1.0)      18.9440 (4.02)     0.0000 (1.0)           0;0  0.0528 (0.25)          1           1
test_perf_sign_psbt_singlesig_wpkh[10]           22.4683 (4.77)     22.4683 (4.77)     22.4683 (4.77)     0.0000 (1.0)      22.4683 (4.77)     0.0000 (1.0)           0;0  0.0445 (0.21)          1           1
test_perf_sign_psbt_singlesig_tr[10]             24.7001 (5.24)     24.7001 (5.24)     24.7001 (5.24)     0.0000 (1.0)      24.7001 (5.24)     0.0000 (1.0)           0;0  0.0405 (0.19)          1           1
test_perf_sign_psbt_multisig2of3_wsh[10]         31.8933 (6.77)     31.8933 (6.77)     31.8933 (6.77)     0.0000 (1.0)      31.8933 (6.77)     0.0000 (1.0)           0;0  0.0314 (0.15)          1           1
test_perf_sign_psbt_singlesig_pkh[10]            39.4850 (8.38)     39.4850 (8.38)     39.4850 (8.38)     0.0000 (1.0)      39.4850 (8.38)     0.0000 (1.0)           0;0  0.0253 (0.12)          1           1
test_perf_sign_psbt_multisig3of5_wsh[10]         47.0507 (9.98)     47.0507 (9.98)     47.0507 (9.98)     0.0000 (1.0)      47.0507 (9.98)     0.0000 (1.0)           0;0  0.0213 (0.10)          1           1
test_perf_sign_psbt_tapminiscript_2paths[10]     50.0241 (10.61)    50.0241 (10.61)    50.0241 (10.61)    0.0000 (1.0)      50.0241 (10.61)    0.0000 (1.0)           0;0  0.0200 (0.09)          1           1
```