### PR TITLE
client_rs: bump bitcoin 0.32 and miniscript 12.2

### DIFF
--- a/bitcoin_client_rs/Cargo.toml
+++ b/bitcoin_client_rs/Cargo.toml
@@ -21,8 +21,8 @@ paranoid_client = ["miniscript"]
 
 [dependencies]
 async-trait = { version = "0.1", optional = true }
-bitcoin = { version = "0.31", default-features = false, features = ["no-std"] }
-miniscript = { version = "11.0", optional = true, default-features = false, features = ["no-std"] }
+bitcoin = { version = "0.32", default-features = false }
+miniscript = { version = "12.2", optional = true, default-features = false, features = ["no-std"] }
 
 [workspace]
 members = ["examples/ledger_hwi"]

--- a/bitcoin_client_rs/Cargo.toml
+++ b/bitcoin_client_rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledger_bitcoin_client"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Edouard Paris <m@edouard.paris>"]
 edition = "2018"
 description = "Ledger Bitcoin application client"

--- a/bitcoin_client_rs/examples/ledger_hwi/Cargo.toml
+++ b/bitcoin_client_rs/examples/ledger_hwi/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 clap = { version = "4.0.18", features = ["derive"] }
 ledger_bitcoin_client = { path = "../.." }
 async-trait = { version = "0.1"}
-bitcoin = { version = "0.31", default-features = false, features = ["no-std"] }
+bitcoin = { version = "0.32", default-features = false }
 hex = "0.4"
 base64 = "0.13.0"
 ledger-apdu = "0.10"

--- a/bitcoin_client_rs/src/async_client.rs
+++ b/bitcoin_client_rs/src/async_client.rs
@@ -91,7 +91,7 @@ impl<T: Transport> BitcoinClient<T> {
                 BitcoinClientError::ClientError("Failed to derive descriptor".to_string())
             })?
             .script_pubkey()
-            != expected_address.payload().script_pubkey()
+            != expected_address.assume_checked_ref().script_pubkey()
         {
             return Err(BitcoinClientError::InvalidResponse("Invalid address. Please update your Bitcoin app. If the problem persists, report a bug at https://github.com/LedgerHQ/app-bitcoin-new".to_string()));
         }

--- a/bitcoin_client_rs/src/client.rs
+++ b/bitcoin_client_rs/src/client.rs
@@ -86,7 +86,7 @@ impl<T: Transport> BitcoinClient<T> {
                 BitcoinClientError::ClientError("Failed to derive descriptor".to_string())
             })?
             .script_pubkey()
-            != expected_address.payload().script_pubkey()
+            != expected_address.assume_checked_ref().script_pubkey()
         {
             return Err(BitcoinClientError::InvalidResponse("Invalid address. Please update your Bitcoin app. If the problem persists, report a bug at https://github.com/LedgerHQ/app-bitcoin-new".to_string()));
         }

--- a/bitcoin_client_rs/src/psbt.rs
+++ b/bitcoin_client_rs/src/psbt.rs
@@ -8,7 +8,7 @@ use bitcoin::{
     consensus::encode::{deserialize, serialize, VarInt},
     ecdsa,
     hashes::Hash,
-    key::Error as KeyError,
+    key::FromSliceError as KeyError,
     psbt::{raw, Input, Output, Psbt},
     secp256k1::{self, XOnlyPublicKey},
     taproot,

--- a/bitcoin_client_rs/src/wallet.rs
+++ b/bitcoin_client_rs/src/wallet.rs
@@ -258,23 +258,33 @@ impl FromStr for WalletPubKey {
 
 impl core::fmt::Display for WalletPubKey {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        if self.source.is_none() {
-            write!(f, "{}", self.inner)
-        } else {
-            write!(
+        match &self.source {
+            None => write!(
                 f,
-                "[{}{}]{}{}",
-                self.source.as_ref().unwrap().0,
-                self.source
-                    .as_ref()
-                    .unwrap()
-                    .1
-                    .to_string()
-                    .strip_prefix('m')
-                    .unwrap_or(""),
+                "{}{}",
                 self.inner,
                 self.multipath.as_ref().unwrap_or(&"".to_string())
-            )
+            ),
+            Some((fg, path)) => {
+                if path.is_master() {
+                    write!(
+                        f,
+                        "[{}]{}{}",
+                        fg,
+                        self.inner,
+                        self.multipath.as_ref().unwrap_or(&"".to_string())
+                    )
+                } else {
+                    write!(
+                        f,
+                        "[{}/{}]{}{}",
+                        fg,
+                        path,
+                        self.inner,
+                        self.multipath.as_ref().unwrap_or(&"".to_string())
+                    )
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This PR updates rust-bitcoin and rust-miniscript dependencies for the ledger_bitcoin_client crate and fixes the breaking change.