### PR TITLE
Remove SonarCloud code analysis on `develop`/`master`

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,10 +1,6 @@
 name: Sonarcloud
 
 on:
-  push:
-    branches:
-      - master
-      - develop
   pull_request:
     branches:
       - master


### PR DESCRIPTION
The CI is red if SonarCloud's reported code coverage is insufficient; since a lot of code is tested in the python integration tests, rather than the C unit tests, this happens way too often to be useful.

This PR removes the SonarCloud job on the `develop` and `master` branches, while keeping it for PRs as it might still provide useful info.