### PR TITLE
Increase `MAX_N_KEYS_IN_WALLET_POLICY` to 15

### DIFF
--- a/.github/workflows/build_and_functional_tests.yml
+++ b/.github/workflows/build_and_functional_tests.yml
@@ -32,3 +32,5 @@ jobs:
     with:
       download_app_binaries_artifact: "compiled_app_binaries"
       container_image: "ghcr.io/ledgerhq/app-bitcoin-new/speculos-bitcoin-musig2:latest"
+      # when merging a PR, we run the tests with the --enableslowtests flag
+      test_options: ${{ github.event_name == 'push' && '--enableslowtests' || '' }}

--- a/.github/workflows/build_and_functional_tests.yml
+++ b/.github/workflows/build_and_functional_tests.yml
@@ -32,5 +32,5 @@ jobs:
     with:
       download_app_binaries_artifact: "compiled_app_binaries"
       container_image: "ghcr.io/ledgerhq/app-bitcoin-new/speculos-bitcoin-musig2:latest"
-      # when merging a PR, we run the tests with the --enableslowtests flag
-      test_options: ${{ github.event_name == 'push' && '--enableslowtests' || '' }}
+      # when merging a PR, we run the tests with the --enable_slow_tests parameter
+      test_options: ${{ github.event_name == 'push' && '--enable_slow_tests' || '' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Dates are in `dd-mm-yyyy` format.
 ### Changed
 
 - For wallet policies with multiple internal spending paths, the app will only sign for key expressions for which the corresponding `PSBT_IN_BIP32_DERIVATION` or `PSBT_IN_TAP_BIP32_DERIVATION` is present in the PSBT. This improves performance when signing for certain spending paths is not desired.
+- Increased the maximum supported number of cosigners in a wallet policy to 15.
 
 ## [2.3.0] - 26-08-2024
 

--- a/src/common/wallet.h
+++ b/src/common/wallet.h
@@ -46,7 +46,7 @@
 
 // Maximum number of keys supported for a wallet policy. It is a technical limit to
 // bound the total memory occupation of a wallet policy, and could be increased if necessary.
-#define MAX_N_KEYS_IN_WALLET_POLICY 10
+#define MAX_N_KEYS_IN_WALLET_POLICY 15
 
 // This amount should be enough for many useful policies
 // We do not expect these limits to be reached in practice any time soon, but they can

--- a/src/ui/display_nbgl.c
+++ b/src/ui/display_nbgl.c
@@ -15,7 +15,7 @@ static const char *confirmed_status;  // text displayed in confirmation page (af
 static const char *rejected_status;   // text displayed in rejection page (after reject confirmed)
 static bool show_message_start_page;
 
-#define N_UX_PAIRS 13
+#define N_UX_PAIRS 18
 
 static nbgl_layoutTagValue_t pairs[N_UX_PAIRS];
 static nbgl_layoutTagValueList_t pairList;

--- a/test_utils/fixtures.py
+++ b/test_utils/fixtures.py
@@ -52,13 +52,13 @@ def pytest_addoption(parser):
     parser.addoption("--hid", action="store_true")
     parser.addoption("--headless", action="store_true")
     parser.addoption(
-        "--enableslowtests",
+        "--enable_slow_tests",
         action="store",
         nargs="?",
         const=1,  # Default to 1 if the flag is provided without a value
         default=0,  # Default to 0 if the flag is not provided
         type=int,
-        help="Enable slow tests: 0 (default), 1 if flag is present, or specify an integer",
+        help="If 0, skip slow tests. If set or equal to 1, enable some slow tests. Greater values enable even slower tests.",
     )
     parser.addoption("--model", action="store", default="nanosp")
 
@@ -99,7 +99,7 @@ def headless(pytestconfig) -> bool:
 
 @pytest.fixture
 def enable_slow_tests(pytestconfig) -> int:
-    return pytestconfig.getoption("enableslowtests")
+    return pytestconfig.getoption("enable_slow_tests")
 
 
 @pytest.fixture

--- a/test_utils/fixtures.py
+++ b/test_utils/fixtures.py
@@ -51,12 +51,20 @@ def get_app_version() -> str:
 def pytest_addoption(parser):
     parser.addoption("--hid", action="store_true")
     parser.addoption("--headless", action="store_true")
-    parser.addoption("--enableslowtests", action="store_true")
+    parser.addoption(
+        "--enableslowtests",
+        action="store",
+        nargs="?",
+        const=1,  # Default to 1 if the flag is provided without a value
+        default=0,  # Default to 0 if the flag is not provided
+        type=int,
+        help="Enable slow tests: 0 (default), 1 if flag is present, or specify an integer",
+    )
     parser.addoption("--model", action="store", default="nanosp")
 
 
 @pytest.fixture(scope="module")
-def sw_h_path():
+def sw_h_path() -> Path:
     # sw.h should be in src/boilerplate/sw.h
     sw_h_path = repo_root_path / "src" / "boilerplate" / "sw.h"
 
@@ -80,22 +88,22 @@ def settings(request) -> dict:
 
 
 @pytest.fixture
-def hid(pytestconfig):
+def hid(pytestconfig) -> bool:
     return pytestconfig.getoption("hid")
 
 
 @pytest.fixture
-def headless(pytestconfig):
+def headless(pytestconfig) -> bool:
     return pytestconfig.getoption("headless")
 
 
 @pytest.fixture
-def enable_slow_tests(pytestconfig):
+def enable_slow_tests(pytestconfig) -> int:
     return pytestconfig.getoption("enableslowtests")
 
 
 @pytest.fixture
-def model(pytestconfig):
+def model(pytestconfig) -> str:
     return pytestconfig.getoption("model")
 
 

--- a/tests/test_e2e_multisig.py
+++ b/tests/test_e2e_multisig.py
@@ -202,8 +202,8 @@ def test_e2e_multisig_15keys(navigator: Navigator, firmware: Firmware, client: R
     # Largest supported quorum in a multisig.
     # The time for an end-to-end execution on a real Ledger Nano S (including user's input) is about 520 seconds.
 
-    # slow test, only run it if --enableslowtests is set
-    if not enable_slow_tests:
+    # slow test, only run it if --enable_slow_tests is set to a value greater than 0
+    if enable_slow_tests < 1:
         pytest.skip()
 
     core_wallet_names: List[str] = []

--- a/tests/test_e2e_multisig.py
+++ b/tests/test_e2e_multisig.py
@@ -198,17 +198,17 @@ def test_e2e_multisig_multiple_internal_keys(navigator: Navigator, firmware: Fir
 
 
 @pytest.mark.timeout(0)  # disable timeout
-def test_e2e_multisig_16_of_16(navigator: Navigator, firmware: Firmware, client: RaggerClient, test_name: str, rpc: AuthServiceProxy, rpc_test_wallet, speculos_globals: SpeculosGlobals, enable_slow_tests: bool):
-    # Largest supported multisig with sortedmulti.
+def test_e2e_multisig_15keys(navigator: Navigator, firmware: Firmware, client: RaggerClient, test_name: str, rpc: AuthServiceProxy, rpc_test_wallet, speculos_globals: SpeculosGlobals, enable_slow_tests: int):
+    # Largest supported quorum in a multisig.
     # The time for an end-to-end execution on a real Ledger Nano S (including user's input) is about 520 seconds.
 
-    # slow test, disabled by default
+    # slow test, only run it if --enableslowtests is set
     if not enable_slow_tests:
         pytest.skip()
 
     core_wallet_names: List[str] = []
     core_xpub_origs: List[str] = []
-    for _ in range(15):
+    for _ in range(14):
         name, xpub_orig = create_new_wallet()
         core_wallet_names.append(name)
         core_xpub_origs.append(xpub_orig)
@@ -225,7 +225,7 @@ def test_e2e_multisig_16_of_16(navigator: Navigator, firmware: Firmware, client:
         [f"[{speculos_globals.master_key_fingerprint.hex()}/{path}]{internal_xpub}"],
     )
 
-    run_test(navigator, client, wallet_policy, core_wallet_names, rpc, rpc_test_wallet,
-             speculos_globals. e2e_register_wallet_instruction(
-                 firmware, wallet_policy.n_keys),
+    run_test(navigator, client, wallet_policy, core_wallet_names,
+             rpc, rpc_test_wallet, speculos_globals,
+             e2e_register_wallet_instruction(firmware, wallet_policy.n_keys),
              e2e_sign_psbt_instruction(firmware), test_name)

--- a/tests/test_sign_psbt.py
+++ b/tests/test_sign_psbt.py
@@ -574,7 +574,7 @@ def test_sign_psbt_singlesig_large_amount(navigator: Navigator, firmware: Firmwa
 def test_sign_psbt_singlesig_wpkh_512to256(navigator: Navigator, firmware: Firmware, client:
                                            RaggerClient, test_name: str, enable_slow_tests: int):
     # PSBT for a transaction with 512 inputs and 256 outputs (maximum currently supported in the app)
-    # Very slow test (esp. with DEBUG enabled), so disabled unless the --enableslowtests option is used
+    # Very slow test (esp. with DEBUG enabled), so disabled unless the --enable_slow_tests option is used
 
     if enable_slow_tests < 2:  # not running by default or in the CI
         pytest.skip()

--- a/tests/test_sign_psbt.py
+++ b/tests/test_sign_psbt.py
@@ -572,11 +572,11 @@ def test_sign_psbt_singlesig_large_amount(navigator: Navigator, firmware: Firmwa
 
 
 def test_sign_psbt_singlesig_wpkh_512to256(navigator: Navigator, firmware: Firmware, client:
-                                           RaggerClient, test_name: str, enable_slow_tests: bool):
+                                           RaggerClient, test_name: str, enable_slow_tests: int):
     # PSBT for a transaction with 512 inputs and 256 outputs (maximum currently supported in the app)
     # Very slow test (esp. with DEBUG enabled), so disabled unless the --enableslowtests option is used
 
-    if not enable_slow_tests:
+    if enable_slow_tests < 2:  # not running by default or in the CI
         pytest.skip()
 
     wallet = WalletPolicy(


### PR DESCRIPTION
This allows complex wallet policies with a larger number of cosigners.
This was supported in past versions, but the cap to 10 keys was introduced in version 2.2.4 together with the UX refactoring.

The memory occupation increases by 160 bytes for devices using NBGL, due to reserving a bigger number of UX pairs (stored in a global).

There is otherwise no increase in memory usage in SIGN_PSBT, and the increase in REGISTER_WALLET is not problematic - plenty of memory is available there.

b8b7d0ccc fixes the corresponding test, and adds it to the CI, but only on merges and not for PRs, as it's rather slow.


Closes: #315
Closes: #317 