### PR TITLE
"Processing" and "returning to Home screen" state machine correction

### DIFF
--- a/src/boilerplate/dispatcher.c
+++ b/src/boilerplate/dispatcher.c
@@ -170,15 +170,12 @@ void apdu_dispatcher(command_descriptor_t const cmd_descriptors[],
         io_send_sw(SW_BAD_STATE);
     }
 
-    // We call the termination callback if given, but only if
-    // - the UX is "dirty", that is either
-    //     - there was some kind of UX flow with user interaction;
-    //     - background processing took long enough that the "Processing..." screen was shown.
-    // - and there has been an error and corresponding response has been sent
-    // Otherwise this is NBGL status callback that will be called
-    bool is_ux_dirty = G_dispatcher_state.had_ux_flow || G_was_processing_screen_shown;
-    if (G_dispatcher_state.termination_cb != NULL && is_ux_dirty &&
-        G_dispatcher_state.sw != SW_OK) {
+    // We call the termination callback if given, but only if:
+    // - there was no UX flow with user interaction;
+    // - and background processing took long enough that the "Processing..." screen was shown.
+    // Otherwise, either nothing was shown on screen, or it is NBGL's responsibility
+    if (!G_dispatcher_state.had_ux_flow && G_dispatcher_state.termination_cb != NULL &&
+        G_was_processing_screen_shown) {
         G_dispatcher_state.termination_cb();
         G_was_processing_screen_shown = 0;
     }

--- a/src/handler/get_wallet_address.c
+++ b/src/handler/get_wallet_address.c
@@ -212,16 +212,5 @@ void handler_get_wallet_address(dispatcher_context_t *dc, uint8_t protocol_versi
         }
 
         SEND_RESPONSE(dc, address, address_len, SW_OK);
-
-        // Workaround for a glitch when get_wallet_address is called right after a UX flow that has
-        // a long confirmation screen (e.g. register_wallet), as processing this command sometimes
-        // lead to the "Processing..." screen not being cleared at the end of the command.
-        // By forcing to show the dashboard, we avoid it; however, this is not a perfect solution,
-        // as it results in cutting short the duration of the "Address verified" status.
-        // This only happens on Flex and Stax, and only for complex policies. Therefore,
-        // we use the workaround for non-default wallets, and only on NBGL devices.
-        if (!is_wallet_default) {
-            ui_menu_main();
-        }
     }
 }

--- a/src/ui/display.c
+++ b/src/ui/display.c
@@ -67,6 +67,10 @@ static bool io_ui_process(dispatcher_context_t *context) {
     UNUSED(context);
     G_was_processing_screen_shown = false;
 
+    // Setting `had_ux_flow` flag meaning that the UI interaction is launched
+    // This is now UI/NBGL that is responsible to return to Home screen
+    G_dispatcher_context.set_ui_dirty();
+
     g_ux_flow_ended = false;
 
     // We are not waiting for the client's input, nor we are doing computations on the device

--- a/tests/instructions.py
+++ b/tests/instructions.py
@@ -104,6 +104,18 @@ def register_wallet_instruction_approve(model: Firmware) -> Instructions:
     return instructions
 
 
+def register_wallet_instruction_approve_no_save(model: Firmware) -> Instructions:
+    instructions = Instructions(model)
+
+    if model.name.startswith("nano"):
+        instructions.new_request("Register account", save_screenshot=False)
+    else:
+        instructions.choice_confirm(save_screenshot=False)
+        instructions.choice_confirm(save_screenshot=False)
+        instructions.choice_confirm(save_screenshot=False)
+    return instructions
+
+
 def register_wallet_instruction_approve_long(model: Firmware) -> Instructions:
     instructions = Instructions(model)
 


### PR DESCRIPTION
- [x] Linked to https://github.com/LedgerHQ/app-bitcoin-new/issues/283 and Based on already exiting `set_ui_dirty() -> had_ux_flow` mechanism.
- [x] fixes `test_get_wallet_address_multisig_legacy_v1_ui` for io revamp case 
- [x] A test with complex policy registration provoking "Loading" message and followed by get address (not displayed) is added

Tested manually/locally/on Speculos with 22 and 24 (io revamp) Speculos/SDK branches.
Tested on Flex (real device)  using:
- test_sighash_single_3_ins_2_out  (supposed to fail on "Loading" without displaying nothing more)
- test_sign_psbt_multiple_derivation_paths 
- new test_get_wallet_address_with_register_complex_policy

This PR cancels  https://github.com/LedgerHQ/app-bitcoin-new/pull/334 one (as #333 removes code whereas #334 adds :) ). 