### PR TITLE
Adaptation to ragger/pull/246 (blocking apdus revamp)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ embit>=0.7.0,<0.8.0
 mnemonic==0.20
 bip32>=3.4,<4.0
 speculos>=0.21.2
-ragger[speculos, ledgerwallet]>=1.35.0
+ragger[speculos, ledgerwallet]>=1.37.0
 -e ./bitcoin_client  # path relative to the current working directory; assume it's the root of the repo


### PR DESCRIPTION
With this change we do not send 2nd identical APDU to Speculos anymore, but we rely on updated async Ragger API.

Depends on: https://github.com/LedgerHQ/ragger/pull/246 