### PR TITLE
Fix failure case for MuSig2 signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are in `dd-mm-yyyy` format.
 
-## [2.4.1] - 09-06-2025
+## [2.4.1] - 03-07-2025
 
 ### Added
 
 ### Changed
 
 - UX rehaul, especially on Nano X and Nano S Plus devices.
+
+### Fixed
+
+- Signing failure for certain PSBTs with wallet policies containing both `musig()` and script paths.
 
 ## [2.4.0] - 07-03-2025
 

--- a/src/handler/sign_psbt.c
+++ b/src/handler/sign_psbt.c
@@ -1869,13 +1869,15 @@ static bool __attribute__((noinline)) sign_transaction_input(dispatcher_context_
                                                     sighash))
                     return false;
             } else if (keyexpr_info->key_expression_ptr->type == KEY_EXPRESSION_MUSIG) {
-                if (!sign_sighash_musig_and_yield(dc,
-                                                  st,
-                                                  signing_state,
-                                                  keyexpr_info,
-                                                  input,
-                                                  cur_input_index,
-                                                  sighash))
+                // we only execute MuSig2 round 2 if there are pubnonces in the PSBT
+                // (otherwise, we are only here just for the other non-musig2 partial signatures)
+                if (st->has_musig2_pub_nonces && !sign_sighash_musig_and_yield(dc,
+                                                                               st,
+                                                                               signing_state,
+                                                                               keyexpr_info,
+                                                                               input,
+                                                                               cur_input_index,
+                                                                               sighash))
                     return false;
             } else {
                 LEDGER_ASSERT(false, "Unreachable");


### PR DESCRIPTION
Fix a logical error that caused the app to return an error when signing a PSBT if both the following are true:
- the wallet policy contains both an internal `musig()` and an internal script spending path
- the PSBT has enough info to execute MuSig2 round 1, and the script signing

In this case, while `sign_transaction_input` is called, partial signatures for the `musig()` placeholders (round 2) can't be produced. Before the fix, the app would erroneously try to execute round 2, which would of course fail.

Closes: #329