### PR TITLE
Add pytest option to choose the speculos port

### DIFF
--- a/test_utils/fixtures.py
+++ b/test_utils/fixtures.py
@@ -48,6 +48,8 @@ def get_app_version() -> str:
     return f"{assignments['APPVERSION_M']}.{assignments['APPVERSION_N']}.{assignments['APPVERSION_P']}"
 
 
+DEFAULT_SPECULOS_PORT = 5000
+
 def pytest_addoption(parser):
     parser.addoption("--hid", action="store_true")
     parser.addoption("--headless", action="store_true")
@@ -61,7 +63,21 @@ def pytest_addoption(parser):
         help="If 0, skip slow tests. If set or equal to 1, enable some slow tests. Greater values enable even slower tests.",
     )
     parser.addoption("--model", action="store", default="nanosp")
-
+    parser.addoption(
+        "--speculos_port",
+        action="store",
+        nargs="?",
+        const=DEFAULT_SPECULOS_PORT, # Use the default speculos port if the option is given without a value
+        default=None,                # None when option not given at all
+        type=int,
+        metavar="N",
+        help=(
+            "port number to use for speculos. Useful to run tests against a running speculos instance. If you pass "
+            f"--speculos_port with no value the default ({DEFAULT_SPECULOS_PORT}) is used; omit the flag entirely "
+            "to let ragger launch speculos and manage the port automatically. The option is useful to run tests "
+            "against a running speculos instance."
+        ),
+    )
 
 @pytest.fixture(scope="module")
 def sw_h_path() -> Path:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ import shutil
 from test_utils import segwit_addr
 from test_utils.authproxy import AuthServiceProxy, JSONRPCException
 from test_utils.fixtures import *
-from typing import Tuple
+from typing import List, Tuple
 import random
 from bip32 import BIP32
 
@@ -32,6 +32,16 @@ MNEMONIC = "glory promote mansion idle axis finger extra february uncover one tr
 configuration.OPTIONAL.CUSTOM_SEED = MNEMONIC
 configuration.OPTIONAL.BACKEND_SCOPE = "function"
 
+
+@pytest.fixture
+def additional_speculos_arguments(request) -> List[str]:
+    # if the --speculos_port argument is given, instruct ragger to use the given port
+    # instead of using a dynamically allocated port
+    speculos_port = request.config.getoption("--speculos_port")
+    if speculos_port is None:
+        return []
+    else:
+        return ["--api-port", str(speculos_port)]
 
 #########################
 ### CONFIGURATION END ###


### PR DESCRIPTION
This allows running tests against a specific speculos instance that is already running, which is useful when debugging.