### PR TITLE
Clang 21 migration

### DIFF
--- a/src/common/wallet.c
+++ b/src/common/wallet.c
@@ -2666,7 +2666,7 @@ int compute_miniscript_policy_ext_info(const policy_node_t *policy_node,
             out->s = count_not_s <= node->k - 1 ? 1 : 0;
             out->e = count_s == node->n ? 1 : 0;
 
-            out->m = (count_e == node->n && count_not_s <= node->k) ? 1 : 0;
+            out->m = (count_e == node->n && count_m == node->n && count_not_s <= node->k) ? 1 : 0;
 
             out->x = 0;
 

--- a/src/common/wallet.h
+++ b/src/common/wallet.h
@@ -233,7 +233,7 @@ typedef enum {
         else {                                                                                   \
             int offset = (uint8_t *) obj - (uint8_t *) relative_ptr;                             \
             LEDGER_ASSERT(offset >= 0 && offset < UINT16_MAX,                                    \
-                          "Relative pointer's offset must be between 0 and 65535");              \
+                          "Relative pointer offset must be in 0-65535 range");                   \
             relative_ptr->offset = (uint16_t) offset;                                            \
         }                                                                                        \
     }

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -168,7 +168,7 @@ int bip32_CKDpub(const serialized_extended_pubkey_t *parent,
 
 void crypto_ripemd160(const uint8_t *in, uint16_t inlen, uint8_t out[static 20]) {
     int res = cx_ripemd160_hash(in, inlen, out);
-    LEDGER_ASSERT(res == CX_OK, "Unexpected error in ripemd160 computation. Returned: %d", res);
+    LEDGER_ASSERT(res == CX_OK, "Error in ripemd160 computation. Returned: %d", res);
 }
 
 void crypto_hash160(const uint8_t *in, uint16_t inlen, uint8_t out[static 20]) {
@@ -176,9 +176,7 @@ void crypto_hash160(const uint8_t *in, uint16_t inlen, uint8_t out[static 20]) {
 
     uint8_t buffer[32];
     int res = cx_hash_sha256(in, inlen, buffer, 32);
-    LEDGER_ASSERT(res == CX_SHA256_SIZE,
-                  "Unexpected error in sha256 computation. Returned: %d",
-                  res);
+    LEDGER_ASSERT(res == CX_SHA256_SIZE, "Error in sha256 computation. Returned: %d", res);
     crypto_ripemd160(buffer, 32, out);
 }
 
@@ -233,13 +231,9 @@ void crypto_get_checksum(const uint8_t *in, uint16_t in_len, uint8_t out[static 
     uint8_t buffer[32];
     size_t res;
     res = cx_hash_sha256(in, in_len, buffer, 32);
-    LEDGER_ASSERT(res == CX_SHA256_SIZE,
-                  "Unexpected error in sha256 computation. Returned: %d",
-                  res);
+    LEDGER_ASSERT(res == CX_SHA256_SIZE, "Error in sha256 computation. Returned: %d", res);
     res = cx_hash_sha256(buffer, 32, buffer, 32);
-    LEDGER_ASSERT(res == CX_SHA256_SIZE,
-                  "Unexpected error in sha256 computation. Returned: %d",
-                  res);
+    LEDGER_ASSERT(res == CX_SHA256_SIZE, "Error in sha256 computation. Returned: %d", res);
     memmove(out, buffer, 4);
 }
 
@@ -278,10 +272,7 @@ uint32_t crypto_get_master_key_fingerprint() {
     uint8_t master_key_identifier[CX_RIPEMD160_SIZE] = {0};
 
     int res = os_perso_get_master_key_identifier(master_key_identifier, CX_RIPEMD160_SIZE);
-    LEDGER_ASSERT(
-        res == CX_OK,
-        "Unexpected error in os_perso_get_master_key_identifier computation. Returned: %d",
-        res);
+    LEDGER_ASSERT(res == CX_OK, "Error in key_identifier computation. Returned: %d", res);
     return read_u32_be(master_key_identifier, 0);
 }
 
@@ -469,15 +460,15 @@ void crypto_tr_tagged_hash_init(cx_sha256_t *hash_context, const uint8_t *tag, u
 
     uint8_t hashtag[32];
     res = crypto_hash_update(&hash_context->header, tag, tag_len);
-    LEDGER_ASSERT(res == CX_OK, "Unexpected error in sha256 computation. Returned: %d", res);
+    LEDGER_ASSERT(res == CX_OK, "Error in sha256 computation. Returned: %d", res);
     res = crypto_hash_digest(&hash_context->header, hashtag, sizeof(hashtag));
-    LEDGER_ASSERT(res == CX_OK, "Unexpected error in sha256 computation. Returned: %d", res);
+    LEDGER_ASSERT(res == CX_OK, "Error in sha256 computation. Returned: %d", res);
 
     cx_sha256_init(hash_context);
     res = crypto_hash_update(&hash_context->header, hashtag, sizeof(hashtag));
-    LEDGER_ASSERT(res == CX_OK, "Unexpected error in sha256 computation. Returned: %d", res);
+    LEDGER_ASSERT(res == CX_OK, "Error in sha256 computation. Returned: %d", res);
     res = crypto_hash_update(&hash_context->header, hashtag, sizeof(hashtag));
-    LEDGER_ASSERT(res == CX_OK, "Unexpected error in sha256 computation. Returned: %d", res);
+    LEDGER_ASSERT(res == CX_OK, "Error in sha256 computation. Returned: %d", res);
 }
 
 void crypto_tr_tapleaf_hash_init(cx_sha256_t *hash_context) {

--- a/src/handler/lib/policy.c
+++ b/src/handler/lib/policy.c
@@ -1730,8 +1730,7 @@ int get_keyexpr_by_index(const policy_node_t *policy,
             int ret = 0;
             policy_node_scriptlist_t *cur_child = r_policy_node_scriptlist(&node->scriptlist);
             for (int script_idx = 0; script_idx < node->n; script_idx++) {
-                LEDGER_ASSERT(cur_child != NULL,
-                              "The script should always have exactly n child scripts");
+                LEDGER_ASSERT(cur_child != NULL, "The script must have exactly n child scripts");
 
                 found = i < (unsigned int) ret;
                 int ret_partial = get_keyexpr_by_index(r_policy_node(&cur_child->script),

--- a/src/handler/sign_psbt.c
+++ b/src/handler/sign_psbt.c
@@ -1680,7 +1680,7 @@ static bool __attribute__((noinline)) sign_transaction_input(dispatcher_context_
     // Sign as segwit input iff it has a witness utxo
     if (!input->has_witnessUtxo) {
         LEDGER_ASSERT(keyexpr_info->key_expression_ptr->type == KEY_EXPRESSION_NORMAL,
-                      "Only plain key expressions are valid for legacy inputs");
+                      "Only plain key expressions for legacy inputs");
         // sign legacy P2PKH or P2SH
 
         // sign_non_witness(non_witness_utxo.vout[psbt.tx.input_[i].prevout.n].scriptPubKey, i)
@@ -1777,7 +1777,7 @@ static bool __attribute__((noinline)) sign_transaction_input(dispatcher_context_
         uint8_t sighash[32];
         if (segwit_version == 0) {
             LEDGER_ASSERT(keyexpr_info->key_expression_ptr->type == KEY_EXPRESSION_NORMAL,
-                          "Only plain key expressions are valid for SegwitV0 inputs");
+                          "Only plain key expressions for SegwitV0 inputs");
             // segwitv0 inputs default to SIGHASH_ALL
             uint8_t sighash_byte =
                 input->has_sighash_type ? (uint8_t) input->sighash_type : SIGHASH_ALL;

--- a/src/handler/sign_psbt.c
+++ b/src/handler/sign_psbt.c
@@ -2027,8 +2027,6 @@ sign_transaction(dispatcher_context_t *dc,
                  const uint8_t internal_inputs[static BITVECTOR_REAL_SIZE(MAX_N_INPUTS_CAN_SIGN)]) {
     LOG_PROCESSOR(__FILE__, __LINE__, __func__);
 
-    int key_expression_index = 0;
-
     // Iterate over all the key expressions that correspond to keys owned by us
     for (size_t i_keyexpr = 0; i_keyexpr < st->n_internal_key_expressions; i_keyexpr++) {
         keyexpr_info_t *keyexpr_info = &st->internal_key_expressions[i_keyexpr];
@@ -2081,8 +2079,6 @@ sign_transaction(dispatcher_context_t *dc,
                 }
             }
         }
-
-        ++key_expression_index;
     }
 
     return true;

--- a/unit-tests/test_wallet.c
+++ b/unit-tests/test_wallet.c
@@ -669,6 +669,10 @@ static void test_miniscript_types(void **state) {
     // Since 'd:' is 'u' we can use it directly inside a thresh. But we can't under P2WSH.
     Test("thresh(2,dv:older(42),s:pk(@0/**),s:pk(@1/**))", "7663012ab269687c205cbdf0646e5db4eaa398f365f2ea7a0e3d419b7e0330e39ce92bddedcac4f9bcac937c20d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65ac935287", TESTMODE_VALID | TESTMODE_NONMAL | TESTMODE_NEEDSIG | TESTMODE_P2WSH_INVALID, 12, 4);
 
+    // Regression test: thresh 'm' (non-malleable) must require all children to have 'm'.
+    // or_b(sha256,a:sha256) has e=1 but m=0 (children lack 's'), so thresh must NOT be NONMAL.
+    Test("thresh(1,or_b(sha256(e38990d0c7fc009880a9c07c23842e886c6bbdc964ce6bdd5817ad357335ee6f),a:sha256(d1ec675902ef1633427ca360b290b0b3045a0d9058ddb5e648b4c3c3224c5c68)),a:0)", "?", TESTMODE_VALID, -1, -1);
+
     // clang-format on
 }
 


### PR DESCRIPTION
- [x] Fixing LEDGER_ASSERT failures with strings exceeding internal MESSAGE_SIZE hard-coded to 50
- [x] Removing unused `key_expression_index` variable
- [x] Fixing `count_m` variable use
    - [x] A non-regression UT