### PR TITLE
Ported various bug fixes from the develop branch to nanos branch

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,30 +1,31 @@
 # An image derived from ledgerhq/speculos but also containing the bitcoin-core binaries
 # compiled from the master branch
 
-FROM ghcr.io/ledgerhq/speculos:latest
+FROM ghcr.io/ledgerhq/speculos:0.25.5
 
 # install git and curl
 RUN apt update -y && apt install -y git curl
 
 # install autotools bitcoin-core build dependencies
-RUN apt install -y automake autotools-dev bsdmainutils build-essential ccache git libboost-dev libboost-filesystem-dev libboost-system-dev libboost-test-dev libevent-dev libminiupnpc-dev libnatpmp-dev libqt5gui5 libqt5core5a libqt5dbus5 libsqlite3-dev libtool libzmq3-dev pkg-config python3 qttools5-dev qttools5-dev-tools qtwayland5 systemtap-sdt-dev
+RUN apt install -y bsdmainutils build-essential cmake pkg-config ccache git libboost-dev libboost-filesystem-dev libboost-system-dev libboost-test-dev libevent-dev libminiupnpc-dev libnatpmp-dev libqt5gui5 libqt5core5a libqt5dbus5 libsqlite3-dev libtool libzmq3-dev pkg-config python3 qttools5-dev qttools5-dev-tools qtwayland5 systemtap-sdt-dev
 
 # clone bitcoin-core from github and compile it
 RUN cd / && \
     git clone --depth=1 https://github.com/bitcoin/bitcoin.git && \
     cd bitcoin && \
-    ./autogen.sh && \
-    ./configure --enable-suppress-external-warnings && \
-    make -j "$(($(nproc)+1))" && \
-    mkdir bin && \
-    cp src/bitcoind src/bitcoin-cli src/bitcoin-tx src/bitcoin-util src/bitcoin-wallet ./bin
+    cmake -B build -DENABLE_IPC=OFF && \
+    cmake --build build && \
+    cmake --install build
 
 
-FROM ghcr.io/ledgerhq/speculos:latest
-COPY --from=0 /bitcoin/bin /bitcoin/bin
+FROM ghcr.io/ledgerhq/speculos:0.25.5
+COPY --from=0 /usr/local/bin/ /usr/local/bin/
+
+# install essential tools
+RUN apt update -y && apt install -y build-essential curl git
 
 # install runtime dependencies for bitcoind
-RUN apt update -y && apt install -y libminiupnpc-dev libminiupnpc-dev libnatpmp-dev libevent-dev libzmq3-dev
+RUN apt install -y libminiupnpc-dev libminiupnpc-dev libnatpmp-dev libevent-dev libzmq3-dev
 
 # Add bitcoin binaries to path
-ENV PATH=/bitcoin/bin:$PATH
+ENV PATH=/usr/local/bin/:$PATH

--- a/.github/workflows/build_and_functional_tests.yml
+++ b/.github/workflows/build_and_functional_tests.yml
@@ -31,4 +31,7 @@ jobs:
     uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_ragger_tests.yml@v1
     with:
       download_app_binaries_artifact: "compiled_app_binaries"
-
+      container_image: "ghcr.io/ledgerhq/app-bitcoin-new/speculos-bitcoin:NanoS_Blue_baseline"
+      # when merging a PR, we run the tests with the --enable_slow_tests parameter
+      test_options: ${{ github.event_name == 'push' && '--enable_slow_tests' || '' }}
+      regenerate_snapshots: ${{ github.event_name == 'workflow_dispatch' && inputs.golden_run == 'Open a PR' }}

--- a/.github/workflows/builder-image-workflow.yml
+++ b/.github/workflows/builder-image-workflow.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Clone
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Build and push speculos-bitcoin to GitHub Packages
       uses: docker/build-push-action@v1
@@ -27,4 +27,4 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
         tag_with_sha: true
-        tags: latest
+        tags: NanoS_Blue_baseline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are in `dd-mm-yyyy` format.
 
+## [2.2.6] - 24-02-2026
+
+### Fixed
+
+- Ported various bug fixes from the `develop` branch.
+
 ## [2.2.5] - 26-08-2024
 
 ### Fixed

--- a/src/common/script.c
+++ b/src/common/script.c
@@ -189,8 +189,8 @@ int format_opscript_script(const uint8_t script[],
         }
 
         if (hex_length == 1) {
-            if (script[offset] == 0x81 || script[offset] <= 16) {
-                // non-standard, it should use OP_1NEGATE, or one of OP_0, ..., OP_16
+            if (script[offset] == 0x81 || (1 <= script[offset] && script[offset] <= 16)) {
+                // non-standard, it should use OP_1NEGATE, or one of OP_1, ..., OP_16
                 return -1;
             }
         }

--- a/src/common/wallet.c
+++ b/src/common/wallet.c
@@ -2798,6 +2798,125 @@ int compute_miniscript_policy_ext_info(const policy_node_t *policy_node,
     }
 }
 
+static int traverse_policy_node_tree(const policy_node_tree_t *tree,
+                                     policy_node_callback_t callback,
+                                     void *callback_state) {
+    if (tree->is_leaf) {
+        return traverse_policy_dfs(r_policy_node(&tree->script), callback, callback_state);
+    } else {
+        int ret = traverse_policy_node_tree(r_policy_node_tree(&tree->left_tree),
+                                            callback,
+                                            callback_state);
+        if (ret < 0) return ret;
+        return traverse_policy_node_tree(r_policy_node_tree(&tree->right_tree),
+                                         callback,
+                                         callback_state);
+    }
+}
+
+int traverse_policy_dfs(const policy_node_t *policy_node,
+                        policy_node_callback_t callback,
+                        void *callback_state) {
+    if (callback == NULL) {
+        return -1;
+    }
+
+    // Visit the current node first (pre-order)
+    int ret = callback(policy_node, callback_state);
+    if (ret < 0) return ret;
+
+    switch (policy_node->type) {
+        // Leaf nodes with no child scripts
+        case TOKEN_0:
+        case TOKEN_1:
+        case TOKEN_PK_K:
+        case TOKEN_PK_H:
+        case TOKEN_PK:
+        case TOKEN_PKH:
+        case TOKEN_WPKH:
+        case TOKEN_OLDER:
+        case TOKEN_AFTER:
+        case TOKEN_SHA256:
+        case TOKEN_HASH256:
+        case TOKEN_RIPEMD160:
+        case TOKEN_HASH160:
+        case TOKEN_MULTI:
+        case TOKEN_MULTI_A:
+        case TOKEN_SORTEDMULTI:
+        case TOKEN_SORTEDMULTI_A:
+            return 0;
+
+        // Nodes with a single child script (including miniscript wrappers)
+        case TOKEN_SH:
+        case TOKEN_WSH:
+        case TOKEN_A:
+        case TOKEN_S:
+        case TOKEN_C:
+        case TOKEN_T:
+        case TOKEN_D:
+        case TOKEN_V:
+        case TOKEN_J:
+        case TOKEN_N:
+        case TOKEN_L:
+        case TOKEN_U: {
+            const policy_node_with_script_t *node = (const policy_node_with_script_t *) policy_node;
+            return traverse_policy_dfs(r_policy_node(&node->script), callback, callback_state);
+        }
+
+        // Nodes with exactly two child scripts
+        case TOKEN_AND_V:
+        case TOKEN_AND_B:
+        case TOKEN_AND_N:
+        case TOKEN_OR_B:
+        case TOKEN_OR_C:
+        case TOKEN_OR_D:
+        case TOKEN_OR_I: {
+            const policy_node_with_script2_t *node =
+                (const policy_node_with_script2_t *) policy_node;
+            ret = traverse_policy_dfs(r_policy_node(&node->scripts[0]), callback, callback_state);
+            if (ret < 0) return ret;
+            return traverse_policy_dfs(r_policy_node(&node->scripts[1]), callback, callback_state);
+        }
+
+        // Nodes with exactly three child scripts
+        case TOKEN_ANDOR: {
+            const policy_node_with_script3_t *node =
+                (const policy_node_with_script3_t *) policy_node;
+            ret = traverse_policy_dfs(r_policy_node(&node->scripts[0]), callback, callback_state);
+            if (ret < 0) return ret;
+            ret = traverse_policy_dfs(r_policy_node(&node->scripts[1]), callback, callback_state);
+            if (ret < 0) return ret;
+            return traverse_policy_dfs(r_policy_node(&node->scripts[2]), callback, callback_state);
+        }
+
+        // Nodes with a linked list of child scripts
+        case TOKEN_THRESH: {
+            const policy_node_thresh_t *node = (const policy_node_thresh_t *) policy_node;
+            policy_node_scriptlist_t *cur = r_policy_node_scriptlist(&node->scriptlist);
+            while (cur != NULL) {
+                ret = traverse_policy_dfs(r_policy_node(&cur->script), callback, callback_state);
+                if (ret < 0) return ret;
+                cur = r_policy_node_scriptlist(&cur->next);
+            }
+            return 0;
+        }
+
+        case TOKEN_TR: {
+            const policy_node_tr_t *node = (const policy_node_tr_t *) policy_node;
+            if (!isnull_policy_node_tree(&node->tree)) {
+                return traverse_policy_node_tree(r_policy_node_tree(&node->tree),
+                                                 callback,
+                                                 callback_state);
+            }
+            return 0;
+        }
+        case TOKEN_INVALID:
+        default:
+            PRINTF("traverse_policy_dfs: unexpected token %d\n", policy_node->type);
+            return -1;
+    }
+}
+
 #ifndef SKIP_FOR_CMOCKA
 
 void get_policy_wallet_id(policy_map_wallet_header_t *wallet_header, uint8_t out[static 32]) {

--- a/src/common/wallet.c
+++ b/src/common/wallet.c
@@ -2558,7 +2558,7 @@ int compute_miniscript_policy_ext_info(const policy_node_t *policy_node,
             out->s = count_not_s <= node->k - 1 ? 1 : 0;
             out->e = count_s == node->n ? 1 : 0;
 
-            out->m = (count_e == node->n && count_not_s <= node->k) ? 1 : 0;
+            out->m = (count_e == node->n && count_m == node->n && count_not_s <= node->k) ? 1 : 0;
 
             out->x = 0;
 

--- a/src/common/wallet.h
+++ b/src/common/wallet.h
@@ -488,6 +488,30 @@ int compute_miniscript_policy_ext_info(const policy_node_t *policy_node,
                                        policy_node_ext_info_t *out,
                                        MiniscriptContext ctx);
 
+/**
+ * Callback type for traverse_policy_script_tree.
+ * Called for each node in depth-first (pre-order) traversal.
+ *
+ * @param node pointer to the current policy node
+ * @param callback_state opaque pointer passed through from the caller
+ * @return 0 on success; a negative number to abort traversal with an error.
+ */
+typedef int (*policy_node_callback_t)(const policy_node_t *node, void *callback_state);
+
+/**
+ * Recursively traverses a descriptor template tree in depth-first (pre-order) order, calling
+ * the callback for each node.
+ * Traversal stops early if the callback returns a negative value.
+ *
+ * @param policy_node pointer to the root of the subtree to traverse
+ * @param callback function called for each node
+ * @param callback_state opaque pointer forwarded to the callback
+ * @return 0 on success; a negative number on error (from callback or unexpected node type).
+ */
+int traverse_policy_dfs(const policy_node_t *policy_node,
+                        policy_node_callback_t callback,
+                        void *callback_state);
+
 #ifndef SKIP_FOR_CMOCKA
 
 /**

--- a/src/common/wallet.h
+++ b/src/common/wallet.h
@@ -489,7 +489,7 @@ int compute_miniscript_policy_ext_info(const policy_node_t *policy_node,
                                        MiniscriptContext ctx);
 
 /**
- * Callback type for traverse_policy_script_tree.
+ * Callback type for traverse_policy_dfs.
  * Called for each node in depth-first (pre-order) traversal.
  *
  * @param node pointer to the current policy node

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -283,18 +283,23 @@ bool crypto_derive_symmetric_key(const char *label, size_t label_len, uint8_t ke
 
     memcpy(label_copy, label, label_len);
 
-    if (os_derive_bip32_with_seed_no_throw(HDW_SLIP21,
-                                           CX_CURVE_SECP256K1,
-                                           (uint32_t *) label_copy,
-                                           label_len,
-                                           key,
-                                           NULL,
-                                           NULL,
-                                           0) != CX_OK) {
-        return false;
+    // The SDK function below requires the output key array to be 64 bytes long
+    uint8_t tmp_key[64] = {0};
+    cx_err_t ret = os_derive_bip32_with_seed_no_throw(HDW_SLIP21,
+                                                      CX_CURVE_SECP256K1,
+                                                      (uint32_t *) label_copy,
+                                                      label_len,
+                                                      tmp_key,
+                                                      NULL,
+                                                      NULL,
+                                                      0);
+    if (ret == CX_OK) {
+        // Only the first 32 bytes are used for SLIP21
+        memcpy(key, tmp_key, 32);
     }
+    explicit_bzero(tmp_key, sizeof(tmp_key));
 
-    return true;
+    return ret == CX_OK;
 }
 
 int get_extended_pubkey_at_path(const uint32_t bip32_path[],

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -269,11 +269,17 @@ uint32_t crypto_get_master_key_fingerprint() {
 }
 
 bool crypto_derive_symmetric_key(const char *label, size_t label_len, uint8_t key[static 32]) {
-    // TODO: is there a better way?
-    //       The label is a byte string in SLIP-0021, but os_derive_bip32_with_seed_no_throw
-    //       accesses the `path` argument as an array of uint32_t, causing a device freeze if memory
-    //       is not aligned.
+    // The label is a byte string in SLIP-0021, but os_derive_bip32_with_seed_no_throw
+    // accesses the `path` argument as an array of uint32_t, causing a device freeze if memory
+    // is not aligned.
+    // As a workaround, we copy the label into a local buffer aligned to 4 bytes.
+
     uint8_t label_copy[32] __attribute__((aligned(4)));
+
+    // Fail if the length of the buffer is longer than the local buffer
+    if (label_len > sizeof(label_copy)) {
+        return false;
+    }
 
     memcpy(label_copy, label, label_len);
 

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -276,7 +276,7 @@ int get_extended_pubkey_at_path(const uint32_t bip32_path[],
  * @param[in]  label
  *   Pointer to the label. The first byte of the label must be 0x00 to comply with SLIP-0021.
  * @param[in]  label_len
- *   Length of the label.
+ *   Length of the label. It must be at most 32 bytes.
  * @param[out] key
  *   Pointer to a 32-byte output buffer that will contain the generated key.
  */

--- a/src/handler/lib/get_merkle_preimage.c
+++ b/src/handler/lib/get_merkle_preimage.c
@@ -106,10 +106,12 @@ int call_get_merkle_preimage(dispatcher_context_t *dispatcher_context,
             return -9;
         }
 
+        data_ptr = dispatcher_context->read_buffer.ptr + dispatcher_context->read_buffer.offset;
+
         // update hash
         crypto_hash_update(
             &hash_context->header,
-            dispatcher_context->read_buffer.ptr + dispatcher_context->read_buffer.offset,
+            data_ptr,
             n_bytes);
 
         // write bytes to output

--- a/src/handler/lib/policy.c
+++ b/src/handler/lib/policy.c
@@ -437,7 +437,7 @@ __attribute__((noinline, warn_unused_result)) static int get_extended_pubkey(
                                                         key_index,
                                                         (uint8_t *) key_info_str,
                                                         sizeof(key_info_str));
-        if (key_info_len == -1) {
+        if (key_info_len < 0) {
             return -1;
         }
 
@@ -1754,7 +1754,7 @@ static int get_pubkey_from_merkle_tree(dispatcher_context_t *dispatcher_context,
                                                     index,
                                                     (uint8_t *) key_info_str,
                                                     sizeof(key_info_str));
-    if (key_info_len == -1) {
+    if (key_info_len < 0) {
         return WITH_ERROR(-1, "Failed to retrieve key info");
     }
 

--- a/src/handler/lib/policy.c
+++ b/src/handler/lib/policy.c
@@ -883,7 +883,7 @@ __attribute__((warn_unused_result)) static int process_multi_a_sortedmulti_a_nod
 
     // bitvector of used keys (only relevant for sorting keys in SORTEDMULTI)
     uint8_t used[BITVECTOR_REAL_SIZE(MAX_PUBKEYS_PER_MULTISIG)];
-    memset(used, 0, sizeof(memset));
+    memset(used, 0, sizeof(used));
 
     for (int i = 0; i < policy->n; i++) {
         uint8_t compressed_pubkey[33];

--- a/src/handler/lib/policy.c
+++ b/src/handler/lib/policy.c
@@ -1852,6 +1852,25 @@ static int is_taptree_miniscript_sane(const policy_node_tree_t *taptree) {
     return 0;
 }
 
+/**
+ * Callback for traverse_policy_dfs that rejects any TOKEN_OLDER node whose argument is not either:
+ * - between 1 and 65535 (inclusive), if bit 22 is cleared (block-based relative timelock)
+ * - between 1 + 2^22 = 4194305 and 65535 + 2^22 = 4259839 (inclusive), if bit 22 is set (time-based
+ * relative timelock) This forces all the bits that have no consensus meaning per BIP-68/BIP-112 to
+ * be zero.
+ */
+static int check_older_node_cb(const policy_node_t *node, void *callback_state) {
+    (void) callback_state;
+    if (node->type == TOKEN_OLDER) {
+        const policy_node_with_uint32_t *older = (const policy_node_with_uint32_t *) node;
+        uint32_t n = older->n & ~SEQUENCE_LOCKTIME_TYPE_FLAG;
+        if (n < 1 || n > 65535) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
 int is_policy_sane(dispatcher_context_t *dispatcher_context,
                    const policy_node_t *policy,
                    int wallet_version,
@@ -1942,6 +1961,20 @@ int is_policy_sane(dispatcher_context_t *dispatcher_context,
             }
         }
     }
+
+    // For relative timelocks with `older(n)`, bits 16 to 21 and 23 to 31 have no consensus meaning
+    // per BIP-68/BIP-112. Therefore, for example, `older(65536)` is equivalent to `older(0)`, which
+    // could be dangerous as the user might expect that a timelock is enforced. For relative
+    // timelocks, we reject any value outside the following safe ranges:
+    // - between 1 and 65535 (inclusive), if bit 22 is cleared (block-based timelock)
+    // - between 1 + 2^22 = 4194305 and 65535 + 2^22 = 4259839 (inclusive), if bit 22 is set
+    // (time-based timelock)
+    //
+    // See also: https://github.com/bitcoin/bitcoin/pull/33135
+    if (0 > traverse_policy_dfs(policy, check_older_node_cb, NULL)) {
+        return WITH_ERROR(-1, "older() argument out of valid range");
+    }
+
     return 0;
 }
 

--- a/src/handler/lib/psbt_parse_rawtx.c
+++ b/src/handler/lib/psbt_parse_rawtx.c
@@ -244,6 +244,11 @@ static int parse_rawtxoutput_scriptpubkey(parse_rawtxoutput_state_t *state, buff
                                 // MAX_PREVOUT_SCRIPTPUBKEY_LEN
                 }
 
+                if (state->scriptpubkey_counter + data_len > MAX_PREVOUT_SCRIPTPUBKEY_LEN) {
+                    return -1;  // exceeding MAX_PREVOUT_SCRIPTPUBKEY_LEN with scriptpubkey_counter
+                                // offset
+                }
+
                 memcpy(state->parent_state->parser_outputs->vout_scriptpubkey +
                            state->scriptpubkey_counter,
                        data,
@@ -342,11 +347,11 @@ static int parse_rawtx_inputs_init(parse_rawtx_state_t *state, buffer_t *buffers
 static int parse_rawtx_inputs(parse_rawtx_state_t *state, buffer_t *buffers[2]) {
     while (state->in_counter < state->n_inputs) {
         while (true) {
-            bool result = parser_run(parse_rawtxinput_steps,
-                                     n_parse_rawtxinput_steps,
-                                     &state->input_parser_context,
-                                     buffers,
-                                     pic);
+            int result = parser_run(parse_rawtxinput_steps,
+                                    n_parse_rawtxinput_steps,
+                                    &state->input_parser_context,
+                                    buffers,
+                                    pic);
             if (result != 1) {
                 return result;  // stream exhausted, or error
             } else {
@@ -384,11 +389,11 @@ static int parse_rawtx_outputs_init(parse_rawtx_state_t *state, buffer_t *buffer
 static int parse_rawtx_outputs(parse_rawtx_state_t *state, buffer_t *buffers[2]) {
     while (state->out_counter < state->n_outputs) {
         while (true) {
-            bool result = parser_run(parse_rawtxoutput_steps,
-                                     n_parse_rawtxoutput_steps,
-                                     &state->output_parser_context,
-                                     buffers,
-                                     pic);
+            int result = parser_run(parse_rawtxoutput_steps,
+                                    n_parse_rawtxoutput_steps,
+                                    &state->output_parser_context,
+                                    buffers,
+                                    pic);
             if (result != 1) {
                 return result;  // stream exhausted, or error
             } else {

--- a/src/handler/lib/stream_preimage.c
+++ b/src/handler/lib/stream_preimage.c
@@ -35,7 +35,7 @@ int call_stream_preimage(dispatcher_context_t *dispatcher_context,
     }
     uint32_t preimage_len = (uint32_t) preimage_len_u64;
 
-    if (preimage_len < 1) {
+    if (preimage_len < 1 || partial_data_len == 0) {
         // at least the initial 0x00 prefix should be there
         return -3;
     }

--- a/src/handler/register_wallet.c
+++ b/src/handler/register_wallet.c
@@ -251,7 +251,10 @@ void handler_register_wallet(dispatcher_context_t *dc, uint8_t protocol_version)
     //       And the signature would be on the concatenation of the wallet id and the metadata.
     //       The client must persist the metadata, together with the signature.
 
-    compute_wallet_hmac(wallet_id, response.hmac);
+    if (!compute_wallet_hmac(wallet_id, response.hmac)) {
+        SEND_SW(dc, SW_BAD_STATE);  // this should never fail
+        return;
+    }
 
     SEND_RESPONSE(dc, &response, sizeof(response), SW_OK);
     ui_post_processing_confirm_wallet_registration(dc, true);

--- a/src/handler/sign_psbt.c
+++ b/src/handler/sign_psbt.c
@@ -1171,8 +1171,8 @@ static bool __attribute__((noinline)) display_output(dispatcher_context_t *dc,
         // Swap feature: do not show the address to the user, but double check it matches
         // the request from app-exchange; it must be the only external output (checked
         // elsewhere).
-        int swap_addr_len = strlen(G_swap_state.destination_address);
-        if (swap_addr_len != address_len ||
+        size_t swap_addr_len = strlen(G_swap_state.destination_address);
+        if (swap_addr_len != (size_t)address_len ||
             0 != strncmp(G_swap_state.destination_address, output_address, address_len)) {
             // address did not match
             PRINTF("Mismatching address for swap\n");

--- a/src/handler/sign_psbt.c
+++ b/src/handler/sign_psbt.c
@@ -234,7 +234,7 @@ static int hash_output_n(dispatcher_context_t *dc,
                                                        1,
                                                        out_script,
                                                        sizeof(out_script));
-    if (out_script_len == -1) {
+    if (out_script_len < 0) {
         return -1;
     }
 
@@ -1257,7 +1257,7 @@ static bool read_outputs(dispatcher_context_t *dc,
                                                        output.in_out.scriptPubKey,
                                                        sizeof(output.in_out.scriptPubKey));
 
-        if (result_len == -1 || result_len > (int) sizeof(output.in_out.scriptPubKey)) {
+        if (result_len < 0  || result_len > (int) sizeof(output.in_out.scriptPubKey)) {
             SEND_SW(dc, SW_INCORRECT_DATA);
             return false;
         }

--- a/src/handler/sign_psbt.c
+++ b/src/handler/sign_psbt.c
@@ -380,6 +380,9 @@ static int get_amount_scriptpubkey_from_psbt(
 
 // Convenience function to share common logic when processing all the
 // PSBT_{IN|OUT}_{TAP}?_BIP32_DERIVATION fields.
+// Note: This function must return -1 only on errors (causing signing to abort).
+//       It should return 1 if a derivation that makes sense for this input/output is found.
+//       It should return 0 otherwise (no match found, but continue the signing flow).
 static int read_change_and_index_from_psbt_bip32_derivation(
     dispatcher_context_t *dc,
     placeholder_info_t *placeholder_info,
@@ -421,7 +424,7 @@ static int read_change_and_index_from_psbt_bip32_derivation(
 
     if (der_len < 2 || der_len > MAX_BIP32_PATH_STEPS) {
         PRINTF("BIP32_DERIVATION path too long\n");
-        return -1;
+        return 0;
     }
 
     // if this derivation path matches the internal placeholder,

--- a/src/handler/sign_psbt/extract_bip32_derivation.c
+++ b/src/handler/sign_psbt/extract_bip32_derivation.c
@@ -7,7 +7,6 @@
 
 #include "../../common/psbt.h"
 #include "../../common/read.h"
-#include "../../common/varint.h"
 
 typedef struct {
     int psbt_key_type;
@@ -27,6 +26,11 @@ static void fpt_der_data_callback(buffer_t *data, void *callback_state) {
 
     if (cs->result < 0) return;  // an error already happened, ignore the rest
 
+    if (data->size == 0) {
+        // ignore empty chunks
+        return;
+    }
+
     // on the first call, compute the length the fingerprint + derivation part of the message.
     // - if non-taproot, then it's the entire message;
     // - if taproot, it's the message after the hashes are removed.
@@ -37,16 +41,24 @@ static void fpt_der_data_callback(buffer_t *data, void *callback_state) {
         if (!is_tap) {
             cs->out_data_length = cs->total_data_length;
         } else {
-            uint64_t n_hashes;
-            if ((!buffer_read_varint(data, &n_hashes)) ||
-                (cs->total_data_length < varint_size(n_hashes) + 32 * (int) n_hashes)) {
+            // While BIP-0174 defines the number of hashes as a compact size integer, this
+            // can never be more than 128 in taproot. Since such numbers are always encoded
+            // as a single byte, we simplify by reading a single byte instead of a varint.
+            uint8_t n_hashes;
+            if ((!buffer_read_u8(data, &n_hashes)) ||
+                (cs->total_data_length < 1 + 32 * (int) n_hashes)) {
                 PRINTF("Unexpected: initial callback message too short\n");
                 cs->result = -1;
                 return;
             }
 
-            int out_data_length =
-                cs->total_data_length - varint_size(n_hashes) - 32 * (int) n_hashes;
+            if (n_hashes > 128) {
+                PRINTF("Unexpected: too many hashes in taproot BIP32 derivation\n");
+                cs->result = -1;
+                return;
+            }
+
+            int out_data_length = cs->total_data_length - 1 - 32 * (int) n_hashes;
 
             if (out_data_length > 4 * (1 + MAX_BIP32_PATH_STEPS)) {
                 PRINTF("BIP32 derivation longer than supported in psbt derivation\n");
@@ -69,9 +81,9 @@ static void fpt_der_data_callback(buffer_t *data, void *callback_state) {
         buffer_seek_set(data, 0);
         // We need to concatenate the new data we are reading with any previously read data.
         // Since we can only read data->size bytes, only the last d = out_data_length - data->size
-        // previous bytes are kept; they move from position out_data_length - d + 1 to position 0.
+        // previous bytes are kept; they move from position out_data_length - d to position 0.
         int d = cs->out_data_length - data->size;
-        memmove(cs->out, &cs->out[cs->out_data_length - d + 1], d);
+        memmove(cs->out, &cs->out[cs->out_data_length - d], d);
         // starting at position d, we read the entire data
         buffer_read_bytes(data, &cs->out[d], data->size);
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,7 @@ def run_bitcoind():
     # Run bitcoind in a separate folder
     os.makedirs(BITCOIN_DIRNAME, exist_ok=True)
 
-    bitcoind = os.getenv("BITCOIND", "/bitcoin/bin/bitcoind")
+    bitcoind = os.getenv("BITCOIND", "bitcoind")
 
     shutil.copy(os.path.join(os.path.dirname(__file__), "bitcoin.conf"), BITCOIN_DIRNAME)
     subprocess.Popen([bitcoind, f"--datadir={BITCOIN_DIRNAME}"])

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,4 +6,5 @@ typing-extensions>=3.7,<4.0
 embit>=0.7.0,<0.8.0
 mnemonic==0.20
 bip32>=3.4,<4.0
-ragger[speculos, ledgerwallet]>=1.6.0
+speculos==0.25.5
+ragger[ledgerwallet]>=1.6.0

--- a/tests/test_e2e_miniscript.py
+++ b/tests/test_e2e_miniscript.py
@@ -80,7 +80,7 @@ def run_test_e2e(navigator: Navigator, client: RaggerClient, wallet_policy: Wall
     rpc_test_wallet.sendtoaddress(T(address_hww), "0.1")
     generate_blocks(1)
 
-    assert multisig_rpc.getwalletinfo()["balance"] == Decimal("0.1")
+    assert multisig_rpc.getbalances()["mine"]["trusted"] == Decimal("0.1")
 
     # ==> prepare a psbt spending from the wallet
 

--- a/tests/test_e2e_multisig.py
+++ b/tests/test_e2e_multisig.py
@@ -85,7 +85,7 @@ def run_test(navigator: Navigator, client: RaggerClient, wallet_policy: WalletPo
     rpc_test_wallet.sendtoaddress(T(address_hww), "0.1")
     generate_blocks(1)
 
-    assert multisig_rpc.getwalletinfo()["balance"] == Decimal("0.1")
+    assert multisig_rpc.getbalances()["mine"]["trusted"] == Decimal("0.1")
 
     # ==> prepare a psbt spending from the multisig wallet
 

--- a/tests/test_e2e_tapscripts.py
+++ b/tests/test_e2e_tapscripts.py
@@ -82,7 +82,7 @@ def run_test_e2e(navigator: Navigator, client: RaggerClient, wallet_policy: Wall
     rpc_test_wallet.sendtoaddress(T(address_hww), "0.1")
     generate_blocks(1)
 
-    assert multisig_rpc.getwalletinfo()["balance"] == Decimal("0.1")
+    assert multisig_rpc.getbalances()["mine"]["trusted"] == Decimal("0.1")
 
     # ==> prepare a psbt spending from the wallet
 


### PR DESCRIPTION
## Test run with physical Nano S (OS version 2.1.0)
- receive with LW desktop 
- `--backend ledgerwalet` tests
```
pytest tests/test_sign_message.py  --capture=tee-sys --tb=short -v --device nanos --backend ledgerwallet
pytest tests/test_sign_psbt.py::test_sign_psbt_singlesig_pkh_1to1  --capture=tee-sys --tb=short -v --device nanos --backend ledgerwallet
pytest tests/test_register_wallet.py::test_register_wallet_accept_legacy  --capture=tee-sys --tb=short -v --device nanos --backend ledgerwallet
```

## Sizes comparison  
(`make -C . -j DEBUG=0 COIN=bitcoin TARGET=nanos BOLOS_SDK=$NANOS_SDK`)

Elf sections size before (`nanos`) branch:
```
/opt/arm-none-eabi/bin/arm-none-eabi-size build/nanos/bin/app.elf 
   text    data     bss     dec     hex filename
  61474       0    2376   63850    f96a build/nanos/bin/app.elf
```

Elf sections sizes after:
```
opt/arm-none-eabi/bin/arm-none-eabi-size build/nanos/bin/app.elf 
   text    data     bss     dec     hex filename
  61922       0    2376   64298    fb2a build/nanos/bin/app.elf
```
**=> so  61922 - 61474 = 448 bytes of `.text` difference`** 

## CI test results
Call Ledger guidelines_enforcer / Dispatch check / Check APP_LOAD_PARAMS is expected to fail as we've removed Nano S and changed derivation paths parameters.  