### PR TITLE
Reject dangerous relative timelocks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,7 +12,6 @@ SortIncludes: false
 SpaceAfterCStyleCast: true
 AllowShortCaseLabelsOnASingleLine: false
 AllowAllArgumentsOnNextLine: false
-AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: Never
 AllowShortFunctionsOnASingleLine: None
 BinPackArguments: false

--- a/src/common/wallet.c
+++ b/src/common/wallet.c
@@ -2906,6 +2906,125 @@ int compute_miniscript_policy_ext_info(const policy_node_t *policy_node,
     }
 }
 
+static int traverse_policy_node_tree(const policy_node_tree_t *tree,
+                                     policy_node_callback_t callback,
+                                     void *callback_state) {
+    if (tree->is_leaf) {
+        return traverse_policy_dfs(r_policy_node(&tree->script), callback, callback_state);
+    } else {
+        int ret = traverse_policy_node_tree(r_policy_node_tree(&tree->left_tree),
+                                            callback,
+                                            callback_state);
+        if (ret < 0) return ret;
+        return traverse_policy_node_tree(r_policy_node_tree(&tree->right_tree),
+                                         callback,
+                                         callback_state);
+    }
+}
+
+int traverse_policy_dfs(const policy_node_t *policy_node,
+                        policy_node_callback_t callback,
+                        void *callback_state) {
+    if (callback == NULL) {
+        return -1;
+    }
+
+    // Visit the current node first (pre-order)
+    int ret = callback(policy_node, callback_state);
+    if (ret < 0) return ret;
+
+    switch (policy_node->type) {
+        // Leaf nodes with no child scripts
+        case TOKEN_0:
+        case TOKEN_1:
+        case TOKEN_PK_K:
+        case TOKEN_PK_H:
+        case TOKEN_PK:
+        case TOKEN_PKH:
+        case TOKEN_WPKH:
+        case TOKEN_OLDER:
+        case TOKEN_AFTER:
+        case TOKEN_SHA256:
+        case TOKEN_HASH256:
+        case TOKEN_RIPEMD160:
+        case TOKEN_HASH160:
+        case TOKEN_MULTI:
+        case TOKEN_MULTI_A:
+        case TOKEN_SORTEDMULTI:
+        case TOKEN_SORTEDMULTI_A:
+            return 0;
+
+        // Nodes with a single child script (including miniscript wrappers)
+        case TOKEN_SH:
+        case TOKEN_WSH:
+        case TOKEN_A:
+        case TOKEN_S:
+        case TOKEN_C:
+        case TOKEN_T:
+        case TOKEN_D:
+        case TOKEN_V:
+        case TOKEN_J:
+        case TOKEN_N:
+        case TOKEN_L:
+        case TOKEN_U: {
+            const policy_node_with_script_t *node = (const policy_node_with_script_t *) policy_node;
+            return traverse_policy_dfs(r_policy_node(&node->script), callback, callback_state);
+        }
+
+        // Nodes with exactly two child scripts
+        case TOKEN_AND_V:
+        case TOKEN_AND_B:
+        case TOKEN_AND_N:
+        case TOKEN_OR_B:
+        case TOKEN_OR_C:
+        case TOKEN_OR_D:
+        case TOKEN_OR_I: {
+            const policy_node_with_script2_t *node =
+                (const policy_node_with_script2_t *) policy_node;
+            ret = traverse_policy_dfs(r_policy_node(&node->scripts[0]), callback, callback_state);
+            if (ret < 0) return ret;
+            return traverse_policy_dfs(r_policy_node(&node->scripts[1]), callback, callback_state);
+        }
+
+        // Nodes with exactly three child scripts
+        case TOKEN_ANDOR: {
+            const policy_node_with_script3_t *node =
+                (const policy_node_with_script3_t *) policy_node;
+            ret = traverse_policy_dfs(r_policy_node(&node->scripts[0]), callback, callback_state);
+            if (ret < 0) return ret;
+            ret = traverse_policy_dfs(r_policy_node(&node->scripts[1]), callback, callback_state);
+            if (ret < 0) return ret;
+            return traverse_policy_dfs(r_policy_node(&node->scripts[2]), callback, callback_state);
+        }
+
+        // Nodes with a linked list of child scripts
+        case TOKEN_THRESH: {
+            const policy_node_thresh_t *node = (const policy_node_thresh_t *) policy_node;
+            policy_node_scriptlist_t *cur = r_policy_node_scriptlist(&node->scriptlist);
+            while (cur != NULL) {
+                ret = traverse_policy_dfs(r_policy_node(&cur->script), callback, callback_state);
+                if (ret < 0) return ret;
+                cur = r_policy_node_scriptlist(&cur->next);
+            }
+            return 0;
+        }
+
+        case TOKEN_TR: {
+            const policy_node_tr_t *node = (const policy_node_tr_t *) policy_node;
+            if (!isnull_policy_node_tree(&node->tree)) {
+                return traverse_policy_node_tree(r_policy_node_tree(&node->tree),
+                                                 callback,
+                                                 callback_state);
+            }
+            return 0;
+        }
+        case TOKEN_INVALID:
+        default:
+            PRINTF("traverse_policy_dfs: unexpected token %d\n", policy_node->type);
+            return -1;
+    }
+}
+
 #ifndef SKIP_FOR_CMOCKA
 
 void get_policy_wallet_id(policy_map_wallet_header_t *wallet_header, uint8_t out[static 32]) {

--- a/src/common/wallet.c
+++ b/src/common/wallet.c
@@ -3009,6 +3009,7 @@ int traverse_policy_dfs(const policy_node_t *policy_node,
             return 0;
         }
 
+        // tr nodes with a keypath and (possibly) a taptree
         case TOKEN_TR: {
             const policy_node_tr_t *node = (const policy_node_tr_t *) policy_node;
             if (!isnull_policy_node_tree(&node->tree)) {

--- a/src/common/wallet.h
+++ b/src/common/wallet.h
@@ -508,6 +508,30 @@ int compute_miniscript_policy_ext_info(const policy_node_t *policy_node,
                                        policy_node_ext_info_t *out,
                                        MiniscriptContext ctx);
 
+/**
+ * Callback type for traverse_policy_script_tree.
+ * Called for each node in depth-first (pre-order) traversal.
+ *
+ * @param node pointer to the current policy node
+ * @param callback_state opaque pointer passed through from the caller
+ * @return 0 on success; a negative number to abort traversal with an error.
+ */
+typedef int (*policy_node_callback_t)(const policy_node_t *node, void *callback_state);
+
+/**
+ * Recursively traverses a descriptor template tree in depth-first (pre-order) order, calling
+ * the callback for each node.
+ * Traversal stops early if the callback returns a negative value.
+ *
+ * @param policy_node pointer to the root of the subtree to traverse
+ * @param callback function called for each node
+ * @param callback_state opaque pointer forwarded to the callback
+ * @return 0 on success; a negative number on error (from callback or unexpected node type).
+ */
+int traverse_policy_dfs(const policy_node_t *policy_node,
+                        policy_node_callback_t callback,
+                        void *callback_state);
+
 #ifndef SKIP_FOR_CMOCKA
 
 /**

--- a/src/common/wallet.h
+++ b/src/common/wallet.h
@@ -509,7 +509,7 @@ int compute_miniscript_policy_ext_info(const policy_node_t *policy_node,
                                        MiniscriptContext ctx);
 
 /**
- * Callback type for traverse_policy_script_tree.
+ * Callback type for traverse_policy_dfs.
  * Called for each node in depth-first (pre-order) traversal.
  *
  * @param node pointer to the current policy node

--- a/src/handler/lib/policy.c
+++ b/src/handler/lib/policy.c
@@ -1946,11 +1946,8 @@ static bool are_key_placeholders_identical(const policy_node_keyexpr_t *kp1,
 }
 
 /**
- * Callback for traverse_policy_dfs that rejects any TOKEN_OLDER node whose argument is not either:
- * - between 1 and 65535 (inclusive), if bit 22 is cleared (block-based relative timelock)
- * - between 1 + 2^22 = 4194305 and 65535 + 2^22 = 4259839 (inclusive), if bit 22 is set (time-based
- * relative timelock) This forces all the bits that have no consensus meaning per BIP-68/BIP-112 to
- * be zero.
+ * Callback for traverse_policy_dfs that rejects older(n) nodes with an argument that is not
+ * safe, as it sets bits with no consensus meaning (see comment in is_policy_sane() below).
  */
 static int check_older_node_cb(const policy_node_t *node, void *callback_state) {
     (void) callback_state;
@@ -2096,6 +2093,11 @@ int is_policy_sane(dispatcher_context_t *dispatcher_context,
     // - between 1 and 65535 (inclusive), if bit 22 is cleared (block-based timelock)
     // - between 1 + 2^22 = 4194305 and 65535 + 2^22 = 4259839 (inclusive), if bit 22 is set
     // (time-based timelock)
+    //
+    // Bit 22 is SEQUENCE_LOCKTIME_TYPE_FLAG in BIP-68.
+    // Note that bit 31 (SEQUENCE_LOCKTIME_DISABLE_FLAG) is implicitly excluded, as the argument n
+    // of older(n) is guaranteed to be strictly less than 2^31 per miniscript rules, which are
+    // enforced in the policy parser.
     //
     // See also: https://github.com/bitcoin/bitcoin/pull/33135
     if (0 > traverse_policy_dfs(policy, check_older_node_cb, NULL)) {

--- a/src/handler/lib/policy.c
+++ b/src/handler/lib/policy.c
@@ -1945,6 +1945,25 @@ static bool are_key_placeholders_identical(const policy_node_keyexpr_t *kp1,
     LEDGER_ASSERT(false, "Unreachable code");
 }
 
+/**
+ * Callback for traverse_policy_dfs that rejects any TOKEN_OLDER node whose argument is not either:
+ * - between 1 and 65535 (inclusive), if bit 22 is cleared (block-based relative timelock)
+ * - between 1 + 2^22 = 4194305 and 65535 + 2^22 = 4259839 (inclusive), if bit 22 is set (time-based
+ * relative timelock) This forces all the bits that have no consensus meaning per BIP-68/BIP-112 to
+ * be zero.
+ */
+static int check_older_node_cb(const policy_node_t *node, void *callback_state) {
+    (void) callback_state;
+    if (node->type == TOKEN_OLDER) {
+        const policy_node_with_uint32_t *older = (const policy_node_with_uint32_t *) node;
+        uint32_t n = older->n & ~SEQUENCE_LOCKTIME_TYPE_FLAG;
+        if (n < 1 || n > 65535) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
 int is_policy_sane(dispatcher_context_t *dispatcher_context,
                    const policy_node_t *policy,
                    int wallet_version,
@@ -2069,6 +2088,20 @@ int is_policy_sane(dispatcher_context_t *dispatcher_context,
             }
         }
     }
+
+    // For relative timelocks with `older(n)`, bits 16 to 21 and 23 to 31 have no consensus meaning
+    // per BIP-68/BIP-112. Therefore, for example, `older(65536)` is equivalent to `older(0)`, which
+    // could be dangerous as the user might expect that a timelock is enforced. For relative
+    // timelocks, we reject any value outside the following safe ranges:
+    // - between 1 and 65535 (inclusive), if bit 22 is cleared (block-based timelock)
+    // - between 1 + 2^22 = 4194305 and 65535 + 2^22 = 4259839 (inclusive), if bit 22 is set
+    // (time-based timelock)
+    //
+    // See also: https://github.com/bitcoin/bitcoin/pull/33135
+    if (0 > traverse_policy_dfs(policy, check_older_node_cb, NULL)) {
+        return WITH_ERROR(-1, "older() argument out of valid range");
+    }
+
     return 0;
 }
 

--- a/tests/instructions.py
+++ b/tests/instructions.py
@@ -109,15 +109,15 @@ def wallet_instruction_approve(model: Firmware) -> Instructions:
     return instructions
 
 
-def register_wallet_instruction_approve(model: Firmware) -> Instructions:
+def register_wallet_instruction_approve(model: Firmware, save_screenshot=True) -> Instructions:
     instructions = Instructions(model)
 
     if model.name.startswith("nano"):
-        instructions.new_request("Register account")
+        instructions.new_request("Register account", save_screenshot=save_screenshot)
     else:
-        instructions.choice_confirm()
-        instructions.choice_confirm()
-        instructions.choice_confirm()
+        instructions.choice_confirm(save_screenshot=save_screenshot)
+        instructions.choice_confirm(save_screenshot=save_screenshot)
+        instructions.choice_confirm(save_screenshot=save_screenshot)
     return instructions
 
 
@@ -133,16 +133,16 @@ def register_wallet_instruction_approve_no_save(model: Firmware) -> Instructions
     return instructions
 
 
-def register_wallet_instruction_approve_long(model: Firmware) -> Instructions:
+def register_wallet_instruction_approve_long(model: Firmware, save_screenshot=True) -> Instructions:
     instructions = Instructions(model)
 
     if model.name.startswith("nano"):
-        instructions.new_request("Register account")
+        instructions.new_request("Register account", save_screenshot=save_screenshot)
     else:
-        instructions.choice_confirm()
-        instructions.choice_confirm()
-        instructions.choice_confirm()
-        instructions.choice_confirm()
+        instructions.choice_confirm(save_screenshot=save_screenshot)
+        instructions.choice_confirm(save_screenshot=save_screenshot)
+        instructions.choice_confirm(save_screenshot=save_screenshot)
+        instructions.choice_confirm(save_screenshot=save_screenshot)
     return instructions
 
 

--- a/tests/test_register_wallet.py
+++ b/tests/test_register_wallet.py
@@ -235,6 +235,23 @@ def test_register_miniscript_long_policy(navigator: Navigator, firmware: Firmwar
         wallet_hmac,
     )
 
+def test_register_wallet_minmax_relative_timelocks(navigator: Navigator, firmware: Firmware, client:
+                                                   RaggerClient, test_name: str):
+    # This test makes sure that the minimum and maximum values in the sane range for relative timelocks are accepted.
+    # Since mixing height-based and time-based is not allowed, we separate them in different leaves of a taptree.
+    wallet = WalletPolicy(
+        name="Relative timelocks",
+        descriptor_template="tr(@0/<0;1>/*,{thresh(3,pk(@0/<2;3>/*),s:pk(@1/<2;3>/*),s:pk(@2/<2;3>/*),sln:older(1),sln:older(65535)),thresh(3,pk(@0/<4;5>/*),s:pk(@1/<4;5>/*),s:pk(@2/<4;5>/*),sln:older(4194305),sln:older(4259839))})",
+        keys_info=[
+            "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+            "tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF",
+            "tpubDDV6FDLcCieWUeN7R3vZK2Qs3KuQed3ScTY9EiwMXvyCkLjDbCb8RXaAgWDbkG4tW1BMKVF1zERHnyt78QKd4ZaAYGMJMpvHPwgSSU1AxZ3",
+        ])
+    wallet_id, _ = client.register_wallet(wallet, navigator,
+                                          instructions=register_wallet_instruction_approve_long(
+                                              firmware, save_screenshot=False),
+                                          testname=test_name)
+    assert wallet_id == wallet.id
 
 def test_register_wallet_not_sane_policy(navigator: Navigator, firmware: Firmware, client:
                                          RaggerClient, test_name: str):

--- a/tests/test_register_wallet.py
+++ b/tests/test_register_wallet.py
@@ -351,6 +351,44 @@ def test_register_wallet_not_sane_policy(navigator: Navigator, firmware: Firmwar
     error_code = int.from_bytes(e.value.data, 'big')
     assert error_code == EC_REGISTER_WALLET_POLICY_NOT_SANE
 
+    # Relative timelocks outside of the sane range.
+    # Not testing for older(0), since it's already rejected by the miniscript parser, which enforces 1 <= n < 2^31,
+    # and is therefore rejected with IncorrectDataError rather than NotSupportedError.
+    INVALID_RELATIVE_TIMELOCKS = [65536, (1 << 22) + 0, (1 << 22) + 65536]
+    for invalid_timelock in INVALID_RELATIVE_TIMELOCKS:
+        with pytest.raises(ExceptionRAPDU) as e:
+            client.register_wallet(WalletPolicy(
+                name="Invalid relative timelock",
+                descriptor_template=f"wsh(and_v(v:pk(@0/**),older({invalid_timelock})))",
+                keys_info=[
+                    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+                ],
+            ),
+                navigator,
+                testname=test_name
+            )
+        assert DeviceException.exc.get(e.value.status) == NotSupportedError
+        assert len(e.value.data) == 2
+        error_code = int.from_bytes(e.value.data, 'big')
+        assert error_code == EC_REGISTER_WALLET_POLICY_NOT_SANE
+        # repeat the test for a taproot policy
+        with pytest.raises(ExceptionRAPDU) as e:
+            client.register_wallet(WalletPolicy(
+                name="Invalid relative timelock",
+                descriptor_template=f"tr(@0/<0;1>/*,and_v(v:pk(@0/<2;3>/*),older({invalid_timelock})))",
+                keys_info=[
+                    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+                ],
+            ),
+                navigator,
+                testname=test_name
+            )
+        assert DeviceException.exc.get(e.value.status) == NotSupportedError
+        assert len(e.value.data) == 2
+        error_code = int.from_bytes(e.value.data, 'big')
+        assert error_code == EC_REGISTER_WALLET_POLICY_NOT_SANE
+
+
     # TODO: we can probably not trigger stack and ops limits with the current limits we have on the
     # miniscript policy size; otherwise it would be worth to add tests for them, too.
 

--- a/unit-tests/test_wallet.c
+++ b/unit-tests/test_wallet.c
@@ -676,6 +676,214 @@ static void test_miniscript_types(void **state) {
     // clang-format on
 }
 
+// =============================================================================
+// Tests for traverse_policy_dfs
+// =============================================================================
+
+/**
+ * Callback state for collecting the node types visited during traversal,
+ * in order.
+ * If max_visits >= 0, the callback returns -1 (aborting traversal) after
+ * that many visits.
+ */
+typedef struct {
+    PolicyNodeType types[32];
+    int count;
+    int max_visits;  // -1 means no limit
+} traverse_collect_t;
+
+static int traverse_collect_cb(const policy_node_t *node, void *state_) {
+    traverse_collect_t *s = (traverse_collect_t *) state_;
+    if (s->count < (int) (sizeof(s->types) / sizeof(s->types[0]))) {
+        s->types[s->count] = node->type;
+    }
+    s->count++;
+    if (s->max_visits >= 0 && s->count >= s->max_visits) {
+        return -1;
+    }
+    return 0;
+}
+
+// pkh(@0/**) — a single leaf node; callback is invoked exactly once.
+static void test_traverse_single_leaf(void **state) {
+    (void) state;
+
+    uint8_t out[MAX_WALLET_POLICY_MEMORY_SIZE];
+    assert_true(parse_policy("pkh(@0/**)", out, sizeof(out)) >= 0);
+
+    traverse_collect_t s = {.count = 0, .max_visits = -1};
+    assert_int_equal(traverse_policy_dfs((policy_node_t *) out, traverse_collect_cb, &s), 0);
+    assert_int_equal(s.count, 1);
+    assert_int_equal(s.types[0], TOKEN_PKH);
+}
+
+// wsh(multi(2,@0/**,@1/**)) — outer wrapper then the multi leaf.
+static void test_traverse_wsh_multi(void **state) {
+    (void) state;
+
+    uint8_t out[MAX_WALLET_POLICY_MEMORY_SIZE];
+    assert_true(parse_policy("wsh(multi(2,@0/**,@1/**))", out, sizeof(out)) >= 0);
+
+    traverse_collect_t s = {.count = 0, .max_visits = -1};
+    assert_int_equal(traverse_policy_dfs((policy_node_t *) out, traverse_collect_cb, &s), 0);
+
+    PolicyNodeType expected[] = {TOKEN_WSH, TOKEN_MULTI};
+    assert_int_equal(s.count, 2);
+    for (int i = 0; i < 2; i++) assert_int_equal(s.types[i], expected[i]);
+}
+
+// wsh(or_i(pk(@0/**),pk(@1/**))) — root, binary node, then two leaves.
+static void test_traverse_or_i(void **state) {
+    (void) state;
+
+    uint8_t out[MAX_WALLET_POLICY_MEMORY_SIZE];
+    assert_true(parse_policy("wsh(or_i(pk(@0/**),pk(@1/**)))", out, sizeof(out)) >= 0);
+
+    traverse_collect_t s = {.count = 0, .max_visits = -1};
+    assert_int_equal(traverse_policy_dfs((policy_node_t *) out, traverse_collect_cb, &s), 0);
+
+    PolicyNodeType expected[] = {TOKEN_WSH, TOKEN_OR_I, TOKEN_PK, TOKEN_PK};
+    assert_int_equal(s.count, 4);
+    for (int i = 0; i < 4; i++) assert_int_equal(s.types[i], expected[i]);
+}
+
+// wsh(c:andor(0,pk_k(@0/**),pk_k(@1/**))) — three-child node: visits in
+// pre-order (root, first child, second child, third child).
+static void test_traverse_andor(void **state) {
+    (void) state;
+
+    uint8_t out[MAX_WALLET_POLICY_MEMORY_SIZE];
+    assert_true(parse_policy("wsh(c:andor(0,pk_k(@0/**),pk_k(@1/**)))", out, sizeof(out)) >= 0);
+
+    traverse_collect_t s = {.count = 0, .max_visits = -1};
+    assert_int_equal(traverse_policy_dfs((policy_node_t *) out, traverse_collect_cb, &s), 0);
+
+    // TOKEN_WSH → TOKEN_C → TOKEN_ANDOR → TOKEN_0, TOKEN_PK_K, TOKEN_PK_K
+    PolicyNodeType expected[] = {TOKEN_WSH, TOKEN_C, TOKEN_ANDOR, TOKEN_0, TOKEN_PK_K, TOKEN_PK_K};
+    assert_int_equal(s.count, 6);
+    for (int i = 0; i < 6; i++) assert_int_equal(s.types[i], expected[i]);
+}
+
+// wsh(thresh(2,c:pk_k(@0/**),ac:pk_k(@1/**),ac:pk_k(@2/**))) — thresh node
+// with a linked list of children; verifies all children and their wrappers
+// are visited left-to-right.
+static void test_traverse_thresh(void **state) {
+    (void) state;
+
+    uint8_t out[MAX_WALLET_POLICY_MEMORY_SIZE];
+    assert_true(parse_policy("wsh(thresh(2,c:pk_k(@0/**),ac:pk_k(@1/**),ac:pk_k(@2/**)))",
+                             out,
+                             sizeof(out)) >= 0);
+
+    traverse_collect_t s = {.count = 0, .max_visits = -1};
+    assert_int_equal(traverse_policy_dfs((policy_node_t *) out, traverse_collect_cb, &s), 0);
+
+    // TOKEN_WSH → TOKEN_THRESH →
+    //   child 0: TOKEN_C → TOKEN_PK_K
+    //   child 1: TOKEN_A → TOKEN_C → TOKEN_PK_K   (ac: = a: wrapping c:)
+    //   child 2: TOKEN_A → TOKEN_C → TOKEN_PK_K
+    PolicyNodeType expected[] = {TOKEN_WSH,
+                                 TOKEN_THRESH,
+                                 TOKEN_C,
+                                 TOKEN_PK_K,
+                                 TOKEN_A,
+                                 TOKEN_C,
+                                 TOKEN_PK_K,
+                                 TOKEN_A,
+                                 TOKEN_C,
+                                 TOKEN_PK_K};
+    assert_int_equal(s.count, 10);
+    for (int i = 0; i < 10; i++) assert_int_equal(s.types[i], expected[i]);
+}
+
+// tr(@0/**) — taproot key-path only; no script tree, callback fires once.
+static void test_traverse_tr_no_script(void **state) {
+    (void) state;
+
+    uint8_t out[MAX_WALLET_POLICY_MEMORY_SIZE];
+    assert_true(parse_policy("tr(@0/**)", out, sizeof(out)) >= 0);
+
+    traverse_collect_t s = {.count = 0, .max_visits = -1};
+    assert_int_equal(traverse_policy_dfs((policy_node_t *) out, traverse_collect_cb, &s), 0);
+
+    assert_int_equal(s.count, 1);
+    assert_int_equal(s.types[0], TOKEN_TR);
+}
+
+/** tr(@0/**,pk(@1/**)) — taproot with a single tapleaf. */
+static void test_traverse_tr_one_leaf(void **state) {
+    (void) state;
+
+    uint8_t out[MAX_WALLET_POLICY_MEMORY_SIZE];
+    assert_true(parse_policy("tr(@0/**,pk(@1/**))", out, sizeof(out)) >= 0);
+
+    traverse_collect_t s = {.count = 0, .max_visits = -1};
+    assert_int_equal(traverse_policy_dfs((policy_node_t *) out, traverse_collect_cb, &s), 0);
+
+    // TOKEN_TR fires for the root; then the taptree leaf fires TOKEN_PK
+    PolicyNodeType expected[] = {TOKEN_TR, TOKEN_PK};
+    assert_int_equal(s.count, 2);
+    for (int i = 0; i < 2; i++) assert_int_equal(s.types[i], expected[i]);
+}
+
+/** tr(@0/**,{pk(@1/**),pk(@2/**)}) — taproot with two tapleaves. */
+static void test_traverse_tr_two_leaves(void **state) {
+    (void) state;
+
+    uint8_t out[MAX_WALLET_POLICY_MEMORY_SIZE];
+    assert_true(parse_policy("tr(@0/**,{pk(@1/**),pk(@2/**)})", out, sizeof(out)) >= 0);
+
+    traverse_collect_t s = {.count = 0, .max_visits = -1};
+    assert_int_equal(traverse_policy_dfs((policy_node_t *) out, traverse_collect_cb, &s), 0);
+
+    // root TOKEN_TR; left leaf TOKEN_PK(@1); right leaf TOKEN_PK(@2)
+    PolicyNodeType expected[] = {TOKEN_TR, TOKEN_PK, TOKEN_PK};
+    assert_int_equal(s.count, 3);
+    for (int i = 0; i < 3; i++) assert_int_equal(s.types[i], expected[i]);
+}
+
+/**
+ * tr with a nested taptree (three leaves): left leaf pk(@1), right subtree with
+ * pk(@2) and pk(@3). Verifies that the binary tree structure is traversed
+ * depth-first left-to-right.
+ */
+static void test_traverse_tr_nested_tree(void **state) {
+    (void) state;
+
+    uint8_t out[MAX_WALLET_POLICY_MEMORY_SIZE];
+    // tr(@0/**,{pk(@1/**),{pk(@2/**),pk(@3/**)}})  — nested taptree
+    assert_true(parse_policy("tr(@0/**,{pk(@1/**),{pk(@2/**),pk(@3/**)}})", out, sizeof(out)) >= 0);
+
+    traverse_collect_t s = {.count = 0, .max_visits = -1};
+    assert_int_equal(traverse_policy_dfs((policy_node_t *) out, traverse_collect_cb, &s), 0);
+
+    // TOKEN_TR; left leaf TOKEN_PK(@1); right subtree: TOKEN_PK(@2), TOKEN_PK(@3)
+    PolicyNodeType expected[] = {TOKEN_TR, TOKEN_PK, TOKEN_PK, TOKEN_PK};
+    assert_int_equal(s.count, 4);
+    for (int i = 0; i < 4; i++) assert_int_equal(s.types[i], expected[i]);
+}
+
+/**
+ * Verifies that returning a negative value from the callback aborts the
+ * traversal immediately: when max_visits is set to 2, the traverse should
+ * stop after visiting the second node and return -1.
+ */
+static void test_traverse_callback_abort(void **state) {
+    (void) state;
+
+    uint8_t out[MAX_WALLET_POLICY_MEMORY_SIZE];
+    assert_true(parse_policy("wsh(or_i(pk(@0/**),pk(@1/**)))", out, sizeof(out)) >= 0);
+
+    // The DFS order is: TOKEN_WSH, TOKEN_OR_I, TOKEN_PK, TOKEN_PK.
+    // Abort after seeing 2 nodes; traversal must stop before TOKEN_PK nodes.
+    traverse_collect_t s = {.count = 0, .max_visits = 2};
+    int ret = traverse_policy_dfs((policy_node_t *) out, traverse_collect_cb, &s);
+    assert_true(ret < 0);
+    assert_int_equal(s.count, 2);
+    assert_int_equal(s.types[0], TOKEN_WSH);
+    assert_int_equal(s.types[1], TOKEN_OR_I);
+}
+
 int main() {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_parse_policy_map_singlesig_1),
@@ -691,6 +899,16 @@ int main() {
         cmocka_unit_test(test_get_policy_segwit_version),
         cmocka_unit_test(test_failures),
         cmocka_unit_test(test_miniscript_types),
+        cmocka_unit_test(test_traverse_single_leaf),
+        cmocka_unit_test(test_traverse_wsh_multi),
+        cmocka_unit_test(test_traverse_or_i),
+        cmocka_unit_test(test_traverse_andor),
+        cmocka_unit_test(test_traverse_thresh),
+        cmocka_unit_test(test_traverse_tr_no_script),
+        cmocka_unit_test(test_traverse_tr_one_leaf),
+        cmocka_unit_test(test_traverse_tr_two_leaves),
+        cmocka_unit_test(test_traverse_tr_nested_tree),
+        cmocka_unit_test(test_traverse_callback_abort),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Prevents the user from registering wallet policies that contains an `older(n)` fragment where `n` has non-zero bits in position that have no consensus meaning per [BIP-68](https://github.com/adewaleijalana/bitcoin-bips/blob/master/bip-0068.mediawiki)/[BIP-112](https://github.com/adewaleijalana/bitcoin-bips/blob/master/bip-0112.mediawiki).

For example, this avoids mistakenly registering something like `older(65536)` which effectively has no timelock.