### PR TITLE
Respect lockfile in CI JS tests

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -245,7 +245,7 @@ jobs:
       - name: Run tests
         run: |
           cd bitcoin_client_js
-          yarn install
+          yarn install --immutable
           LOG_SPECULOS=1 LOG_APDUS=1 SPECULOS="/speculos/speculos.py" yarn test
 
   deploy_js_client_check_tag:


### PR DESCRIPTION
Makes sure that the JS client is installed in the CI with the same exact packages specified in `package-lock.json`.