### PR TITLE
Improve signing performance in case of several internal keys

### DIFF
--- a/src/handler/sign_psbt/sign_input.c
+++ b/src/handler/sign_psbt/sign_input.c
@@ -515,6 +515,36 @@ fill_taproot_keyexpr_info(dispatcher_context_t *dc,
     return true;
 }
 
+/**
+ * Pre-pass: identifies which internal key expressions need processing.
+ * If required_type >= 0, only key expressions matching that type are selected.
+ * If required_type < 0, all signable key expressions are selected.
+ */
+static bool select_keyexprs_to_process(
+    dispatcher_context_t *dc,
+    sign_psbt_state_t *st,
+    int required_type,
+    bool keyexpr_to_process[static MAX_INTERNAL_KEY_EXPRESSIONS]) {
+    bool any = false;
+    for (size_t i = 0; i < st->account.n_internal_key_expressions; i++) {
+        keyexpr_to_process[i] = false;
+        keyexpr_info_t *keyexpr_info = &st->account.internal_key_expressions[i];
+        if (!keyexpr_info->to_sign) {
+            continue;
+        }
+        if (required_type >= 0 &&
+            keyexpr_info->key_expression_ptr->type != (KeyExpressionType) required_type) {
+            continue;
+        }
+        if (!fill_keyexpr_info_if_internal(dc, st, keyexpr_info)) {
+            continue;
+        }
+        keyexpr_to_process[i] = true;
+        any = true;
+    }
+    return any;
+}
+
 bool __attribute__((noinline)) produce_musig2_pubnonces(
     dispatcher_context_t *dc,
     sign_psbt_state_t *st,
@@ -527,23 +557,8 @@ bool __attribute__((noinline)) produce_musig2_pubnonces(
         return true;  // nothing to do
     }
 
-    // Pre-pass: identify the MuSig2 key expressions we will produce pubnonces for
     bool keyexpr_to_process[MAX_INTERNAL_KEY_EXPRESSIONS] = {0};
-    bool any_keyexpr_to_process = false;
-    for (size_t i_keyexpr = 0; i_keyexpr < st->account.n_internal_key_expressions; i_keyexpr++) {
-        keyexpr_info_t *keyexpr_info = &st->account.internal_key_expressions[i_keyexpr];
-        if (!keyexpr_info->to_sign ||
-            keyexpr_info->key_expression_ptr->type != KEY_EXPRESSION_MUSIG) {
-            continue;
-        }
-        if (!fill_keyexpr_info_if_internal(dc, st, keyexpr_info)) {
-            continue;
-        }
-        keyexpr_to_process[i_keyexpr] = true;
-        any_keyexpr_to_process = true;
-    }
-
-    if (!any_keyexpr_to_process) {
+    if (!select_keyexprs_to_process(dc, st, KEY_EXPRESSION_MUSIG, keyexpr_to_process)) {
         return true;  // nothing to do
     }
 
@@ -628,22 +643,8 @@ sign_transaction(dispatcher_context_t *dc,
                  const uint8_t internal_inputs[static BITVECTOR_REAL_SIZE(MAX_N_INPUTS_CAN_SIGN)]) {
     LOG_PROCESSOR(__FILE__, __LINE__, __func__);
 
-    // Pre-pass: identify the key expressions we will sign for.
     bool keyexpr_to_process[MAX_INTERNAL_KEY_EXPRESSIONS] = {0};
-    bool any_keyexpr_to_process = false;
-    for (size_t i_keyexpr = 0; i_keyexpr < st->account.n_internal_key_expressions; i_keyexpr++) {
-        keyexpr_info_t *keyexpr_info = &st->account.internal_key_expressions[i_keyexpr];
-        if (!keyexpr_info->to_sign) {
-            continue;
-        }
-        if (!fill_keyexpr_info_if_internal(dc, st, keyexpr_info)) {
-            continue;
-        }
-        keyexpr_to_process[i_keyexpr] = true;
-        any_keyexpr_to_process = true;
-    }
-
-    if (!any_keyexpr_to_process) {
+    if (!select_keyexprs_to_process(dc, st, -1, keyexpr_to_process)) {
         return true;
     }
 

--- a/src/handler/sign_psbt/sign_input.c
+++ b/src/handler/sign_psbt/sign_input.c
@@ -585,34 +585,40 @@ bool __attribute__((noinline)) produce_musig2_pubnonces(
             return false;
         }
 
-        // The taptree hash only depends on the input (change, address_index) and the policy,
-        // so it is computed once per input and reused for every MuSig2 key expression below.
-        policy_node_tr_t *policy = (policy_node_tr_t *) st->account.policy_map;
-        bool has_taptree = !isnull_policy_node_tree(&policy->tree);
-        if (has_taptree) {
-            if (0 > compute_taptree_hash(
-                        dc,
-                        &(wallet_derivation_info_t){
-                            .address_index = input.in_out.address_index,
-                            .change = input.in_out.is_change ? 1 : 0,
-                            .keys_merkle_root = st->account.wallet_header.keys_info_merkle_root,
-                            .n_keys = st->account.wallet_header.n_keys,
-                            .wallet_version = st->account.wallet_header.version,
-                            .sign_psbt_cache = sign_psbt_cache},
-                        r_policy_node_tree(&policy->tree),
-                        input.taptree_hash)) {
-                PRINTF("Error while computing taptree hash\n");
-                SEND_SW(dc, SW_BAD_STATE);
-                return false;
-            }
-        }
-
         for (size_t i_keyexpr = 0; i_keyexpr < st->account.n_internal_key_expressions;
              i_keyexpr++) {
             if (!keyexpr_to_process[i_keyexpr]) {
                 continue;
             }
             keyexpr_info_t *keyexpr_info = &st->account.internal_key_expressions[i_keyexpr];
+
+            if (!keyexpr_info->is_tapscript) {
+                // The taptree hash only depends on the input (change, address_index) and the
+                // policy, so it could be computed outside of this loop. However, it is only needed
+                // for at most a single key placeholder (the taproot keypath, if it's a musig with
+                // an internal key), and might not be needed at all otherwise. Therefore, it is
+                // actually more efficient to compute it here.
+                policy_node_tr_t *policy = (policy_node_tr_t *) st->account.policy_map;
+                bool has_taptree = !isnull_policy_node_tree(&policy->tree);
+                if (has_taptree) {
+                    if (0 >
+                        compute_taptree_hash(
+                            dc,
+                            &(wallet_derivation_info_t){
+                                .address_index = input.in_out.address_index,
+                                .change = input.in_out.is_change ? 1 : 0,
+                                .keys_merkle_root = st->account.wallet_header.keys_info_merkle_root,
+                                .n_keys = st->account.wallet_header.n_keys,
+                                .wallet_version = st->account.wallet_header.version,
+                                .sign_psbt_cache = sign_psbt_cache},
+                            r_policy_node_tree(&policy->tree),
+                            input.taptree_hash)) {
+                        PRINTF("Error while computing taptree hash\n");
+                        SEND_SW(dc, SW_BAD_STATE);
+                        return false;
+                    }
+                }
+            }
 
             // TODO: code duplication with sign_transaction_input
             if (keyexpr_info->tapleaf_ptr != NULL) {

--- a/src/handler/sign_psbt/sign_input.c
+++ b/src/handler/sign_psbt/sign_input.c
@@ -527,72 +527,92 @@ bool __attribute__((noinline)) produce_musig2_pubnonces(
         return true;  // nothing to do
     }
 
-    // Iterate over all the key expressions that correspond to keys owned by us
+    // Pre-pass: identify the MuSig2 key expressions we will produce pubnonces for
+    bool keyexpr_to_process[MAX_INTERNAL_KEY_EXPRESSIONS] = {0};
+    bool any_keyexpr_to_process = false;
     for (size_t i_keyexpr = 0; i_keyexpr < st->account.n_internal_key_expressions; i_keyexpr++) {
         keyexpr_info_t *keyexpr_info = &st->account.internal_key_expressions[i_keyexpr];
         if (!keyexpr_info->to_sign ||
             keyexpr_info->key_expression_ptr->type != KEY_EXPRESSION_MUSIG) {
             continue;
         }
-
         if (!fill_keyexpr_info_if_internal(dc, st, keyexpr_info)) {
             continue;
         }
+        keyexpr_to_process[i_keyexpr] = true;
+        any_keyexpr_to_process = true;
+    }
 
-        for (unsigned int i = 0; i < st->n_inputs; i++) {
-            if (bitvector_get(internal_inputs, i)) {
-                input_info_t input;
-                memset(&input, 0, sizeof(input));
+    if (!any_keyexpr_to_process) {
+        return true;  // nothing to do
+    }
 
-                input_keys_callback_data_t callback_data = {.input = &input, .state = st};
-                int res = call_get_merkleized_map_with_callback(
-                    dc,
-                    (void *) &callback_data,
-                    st->inputs_root,
-                    st->n_inputs,
-                    i,
-                    (merkle_tree_elements_callback_t) input_keys_callback,
-                    &input.in_out.map);
-                if (res < 0) {
-                    SEND_SW(dc, SW_INCORRECT_DATA);
+    // Iterate over all internal inputs
+    for (unsigned int i = 0; i < st->n_inputs; i++) {
+        if (!bitvector_get(internal_inputs, i)) {
+            continue;
+        }
+
+        input_info_t input;
+        memset(&input, 0, sizeof(input));
+
+        input_keys_callback_data_t callback_data = {.input = &input, .state = st};
+        int res = call_get_merkleized_map_with_callback(
+            dc,
+            (void *) &callback_data,
+            st->inputs_root,
+            st->n_inputs,
+            i,
+            (merkle_tree_elements_callback_t) input_keys_callback,
+            &input.in_out.map);
+        if (res < 0) {
+            SEND_SW(dc, SW_INCORRECT_DATA);
+            return false;
+        }
+
+        // The taptree hash only depends on the input (change, address_index) and the policy,
+        // so it is computed once per input and reused for every MuSig2 key expression below.
+        policy_node_tr_t *policy = (policy_node_tr_t *) st->account.policy_map;
+        bool has_taptree = !isnull_policy_node_tree(&policy->tree);
+        if (has_taptree) {
+            if (0 > compute_taptree_hash(
+                        dc,
+                        &(wallet_derivation_info_t){
+                            .address_index = input.in_out.address_index,
+                            .change = input.in_out.is_change ? 1 : 0,
+                            .keys_merkle_root = st->account.wallet_header.keys_info_merkle_root,
+                            .n_keys = st->account.wallet_header.n_keys,
+                            .wallet_version = st->account.wallet_header.version,
+                            .sign_psbt_cache = sign_psbt_cache},
+                        r_policy_node_tree(&policy->tree),
+                        input.taptree_hash)) {
+                PRINTF("Error while computing taptree hash\n");
+                SEND_SW(dc, SW_BAD_STATE);
+                return false;
+            }
+        }
+
+        for (size_t i_keyexpr = 0; i_keyexpr < st->account.n_internal_key_expressions;
+             i_keyexpr++) {
+            if (!keyexpr_to_process[i_keyexpr]) {
+                continue;
+            }
+            keyexpr_info_t *keyexpr_info = &st->account.internal_key_expressions[i_keyexpr];
+
+            // TODO: code duplication with sign_transaction_input
+            if (keyexpr_info->tapleaf_ptr != NULL) {
+                if (!fill_taproot_keyexpr_info(dc,
+                                               st,
+                                               &input,
+                                               keyexpr_info->tapleaf_ptr,
+                                               keyexpr_info,
+                                               sign_psbt_cache)) {
                     return false;
                 }
+            }
 
-                // TODO: code duplication with sign_transaction_input
-                if (keyexpr_info->tapleaf_ptr != NULL) {
-                    if (!fill_taproot_keyexpr_info(dc,
-                                                   st,
-                                                   &input,
-                                                   keyexpr_info->tapleaf_ptr,
-                                                   keyexpr_info,
-                                                   sign_psbt_cache)) {
-                        return false;
-                    }
-                }
-
-                policy_node_tr_t *policy = (policy_node_tr_t *) st->account.policy_map;
-                if (!isnull_policy_node_tree(&policy->tree)) {
-                    if (0 >
-                        compute_taptree_hash(
-                            dc,
-                            &(wallet_derivation_info_t){
-                                .address_index = input.in_out.address_index,
-                                .change = input.in_out.is_change ? 1 : 0,
-                                .keys_merkle_root = st->account.wallet_header.keys_info_merkle_root,
-                                .n_keys = st->account.wallet_header.n_keys,
-                                .wallet_version = st->account.wallet_header.version,
-                                .sign_psbt_cache = sign_psbt_cache},
-                            r_policy_node_tree(&policy->tree),
-                            input.taptree_hash)) {
-                        PRINTF("Error while computing taptree hash\n");
-                        SEND_SW(dc, SW_BAD_STATE);
-                        return false;
-                    }
-                }
-
-                if (!produce_and_yield_pubnonce(dc, st, signing_state, keyexpr_info, &input, i)) {
-                    return false;
-                }
+            if (!produce_and_yield_pubnonce(dc, st, signing_state, keyexpr_info, &input, i)) {
+                return false;
             }
         }
     }
@@ -608,56 +628,75 @@ sign_transaction(dispatcher_context_t *dc,
                  const uint8_t internal_inputs[static BITVECTOR_REAL_SIZE(MAX_N_INPUTS_CAN_SIGN)]) {
     LOG_PROCESSOR(__FILE__, __LINE__, __func__);
 
-    // Iterate over all the key expressions that correspond to keys owned by us
+    // Pre-pass: identify the key expressions we will sign for.
+    bool keyexpr_to_process[MAX_INTERNAL_KEY_EXPRESSIONS] = {0};
+    bool any_keyexpr_to_process = false;
     for (size_t i_keyexpr = 0; i_keyexpr < st->account.n_internal_key_expressions; i_keyexpr++) {
         keyexpr_info_t *keyexpr_info = &st->account.internal_key_expressions[i_keyexpr];
         if (!keyexpr_info->to_sign) {
             continue;
         }
-
         if (!fill_keyexpr_info_if_internal(dc, st, keyexpr_info)) {
             continue;
         }
+        keyexpr_to_process[i_keyexpr] = true;
+        any_keyexpr_to_process = true;
+    }
 
-        for (unsigned int i = 0; i < st->n_inputs; i++) {
-            if (bitvector_get(internal_inputs, i)) {
-                input_info_t input;
-                memset(&input, 0, sizeof(input));
+    if (!any_keyexpr_to_process) {
+        return true;
+    }
 
-                input_keys_callback_data_t callback_data = {.input = &input, .state = st};
-                int res = call_get_merkleized_map_with_callback(
-                    dc,
-                    (void *) &callback_data,
-                    st->inputs_root,
-                    st->n_inputs,
-                    i,
-                    (merkle_tree_elements_callback_t) input_keys_callback,
-                    &input.in_out.map);
-                if (res < 0) {
-                    SEND_SW(dc, SW_INCORRECT_DATA);
-                    return false;
-                }
-                if (keyexpr_info->tapleaf_ptr != NULL &&
-                    !fill_taproot_keyexpr_info(dc,
-                                               st,
-                                               &input,
-                                               keyexpr_info->tapleaf_ptr,
-                                               keyexpr_info,
-                                               sign_psbt_cache)) {
-                    return false;
-                }
+    // Iterate over all internal inputs
+    for (unsigned int i = 0; i < st->n_inputs; i++) {
+        if (!bitvector_get(internal_inputs, i)) {
+            continue;
+        }
 
-                if (!sign_transaction_input(dc,
-                                            st,
-                                            sign_psbt_cache,
-                                            signing_state,
-                                            keyexpr_info,
-                                            &input,
-                                            i)) {
-                    // we do not send a status word, since sign_transaction_input
-                    // already does it on failure
-                    return false;
-                }
+        input_info_t input;
+        memset(&input, 0, sizeof(input));
+
+        input_keys_callback_data_t callback_data = {.input = &input, .state = st};
+        int res = call_get_merkleized_map_with_callback(
+            dc,
+            (void *) &callback_data,
+            st->inputs_root,
+            st->n_inputs,
+            i,
+            (merkle_tree_elements_callback_t) input_keys_callback,
+            &input.in_out.map);
+        if (res < 0) {
+            SEND_SW(dc, SW_INCORRECT_DATA);
+            return false;
+        }
+
+        for (size_t i_keyexpr = 0; i_keyexpr < st->account.n_internal_key_expressions;
+             i_keyexpr++) {
+            if (!keyexpr_to_process[i_keyexpr]) {
+                continue;
+            }
+            keyexpr_info_t *keyexpr_info = &st->account.internal_key_expressions[i_keyexpr];
+
+            if (keyexpr_info->tapleaf_ptr != NULL &&
+                !fill_taproot_keyexpr_info(dc,
+                                           st,
+                                           &input,
+                                           keyexpr_info->tapleaf_ptr,
+                                           keyexpr_info,
+                                           sign_psbt_cache)) {
+                return false;
+            }
+
+            if (!sign_transaction_input(dc,
+                                        st,
+                                        sign_psbt_cache,
+                                        signing_state,
+                                        keyexpr_info,
+                                        &input,
+                                        i)) {
+                // we do not send a status word, since sign_transaction_input
+                // already does it on failure
+                return false;
             }
         }
     }


### PR DESCRIPTION
Refactors the signing code so that it follows the structure
```
   for each input:
      <validate input>
       for each key placeholder:
           <do things>
```
instead of the current:

```
   for each key placeholder:
       for each input:
          <validate input>
          <do things>
```

This avoids some redundant repeated validation in the case of signing transactions for wallet policies with multiple key placeholders.

Among the existing benchmarks, performance stays the same everywhere (the app only signs for one key placeholder in most cases), except on `_tapminiscript_2paths`, as expected - where there is a performance gain of up to about 10% (measured on a Flex). The gain would likely be larger for more complex policies where the device is in more than 2 spending paths - we currently don't have benchmarks for those.

In any case, the refactoring makes sense for clarity, as the new looping logic is semantically more sound.


```
BEFORE THE PR

--------------------------------------------------------------------------------------------- benchmark: 18 tests ---------------------------------------------------------------------------------------------
Name (time in s)                                     Min                Max               Mean            StdDev             Median               IQR            Outliers     OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 test_perf_sign_psbt_singlesig_wpkh[1]             4.3328 (1.0)       4.3328 (1.0)       4.3328 (1.0)      0.0000 (1.0)       4.3328 (1.0)      0.0000 (1.0)           0;0  0.2308 (1.0)           1           1
 test_perf_sign_psbt_singlesig_pkh[1]              4.7488 (1.10)      4.7488 (1.10)      4.7488 (1.10)     0.0000 (1.0)       4.7488 (1.10)     0.0000 (1.0)           0;0  0.2106 (0.91)          1           1
 test_perf_sign_psbt_singlesig_tr[1]               4.9084 (1.13)      4.9084 (1.13)      4.9084 (1.13)     0.0000 (1.0)       4.9084 (1.13)     0.0000 (1.0)           0;0  0.2037 (0.88)          1           1
 test_perf_sign_psbt_multisig2of3_wsh[1]           6.1930 (1.43)      6.1930 (1.43)      6.1930 (1.43)     0.0000 (1.0)       6.1930 (1.43)     0.0000 (1.0)           0;0  0.1615 (0.70)          1           1
 test_perf_sign_psbt_singlesig_wpkh[3]             8.0289 (1.85)      8.0289 (1.85)      8.0289 (1.85)     0.0000 (1.0)       8.0289 (1.85)     0.0000 (1.0)           0;0  0.1245 (0.54)          1           1
 test_perf_sign_psbt_singlesig_tr[3]               8.5446 (1.97)      8.5446 (1.97)      8.5446 (1.97)     0.0000 (1.0)       8.5446 (1.97)     0.0000 (1.0)           0;0  0.1170 (0.51)          1           1
 test_perf_sign_psbt_multisig3of5_wsh[1]          10.2027 (2.35)     10.2027 (2.35)     10.2027 (2.35)     0.0000 (1.0)      10.2027 (2.35)     0.0000 (1.0)           0;0  0.0980 (0.42)          1           1
 test_perf_sign_psbt_singlesig_pkh[3]             10.2297 (2.36)     10.2297 (2.36)     10.2297 (2.36)     0.0000 (1.0)      10.2297 (2.36)     0.0000 (1.0)           0;0  0.0978 (0.42)          1           1
*test_perf_sign_psbt_tapminiscript_2paths[1]      10.3496 (2.39)     10.3496 (2.39)     10.3496 (2.39)     0.0000 (1.0)      10.3496 (2.39)     0.0000 (1.0)           0;0  0.0966 (0.42)          1           1
 test_perf_sign_psbt_multisig2of3_wsh[3]          12.9687 (2.99)     12.9687 (2.99)     12.9687 (2.99)     0.0000 (1.0)      12.9687 (2.99)     0.0000 (1.0)           0;0  0.0771 (0.33)          1           1
 test_perf_sign_psbt_multisig3of5_wsh[3]          19.6272 (4.53)     19.6272 (4.53)     19.6272 (4.53)     0.0000 (1.0)      19.6272 (4.53)     0.0000 (1.0)           0;0  0.0509 (0.22)          1           1
 test_perf_sign_psbt_singlesig_wpkh[10]           21.3328 (4.92)     21.3328 (4.92)     21.3328 (4.92)     0.0000 (1.0)      21.3328 (4.92)     0.0000 (1.0)           0;0  0.0469 (0.20)          1           1
*test_perf_sign_psbt_tapminiscript_2paths[3]      22.2328 (5.13)     22.2328 (5.13)     22.2328 (5.13)     0.0000 (1.0)      22.2328 (5.13)     0.0000 (1.0)           0;0  0.0450 (0.19)          1           1
 test_perf_sign_psbt_singlesig_tr[10]             22.9660 (5.30)     22.9660 (5.30)     22.9660 (5.30)     0.0000 (1.0)      22.9660 (5.30)     0.0000 (1.0)           0;0  0.0435 (0.19)          1           1
 test_perf_sign_psbt_multisig2of3_wsh[10]         34.2057 (7.89)     34.2057 (7.89)     34.2057 (7.89)     0.0000 (1.0)      34.2057 (7.89)     0.0000 (1.0)           0;0  0.0292 (0.13)          1           1
 test_perf_sign_psbt_singlesig_pkh[10]            45.3476 (10.47)    45.3476 (10.47)    45.3476 (10.47)    0.0000 (1.0)      45.3476 (10.47)    0.0000 (1.0)           0;0  0.0221 (0.10)          1           1
 test_perf_sign_psbt_multisig3of5_wsh[10]         54.2860 (12.53)    54.2860 (12.53)    54.2860 (12.53)    0.0000 (1.0)      54.2860 (12.53)    0.0000 (1.0)           0;0  0.0184 (0.08)          1           1
*test_perf_sign_psbt_tapminiscript_2paths[10]     61.3794 (14.17)    61.3794 (14.17)    61.3794 (14.17)    0.0000 (1.0)      61.3794 (14.17)    0.0000 (1.0)           0;0  0.0163 (0.07)          1           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


AFTER THE PR

--------------------------------------------------------------------------------------------- benchmark: 18 tests ---------------------------------------------------------------------------------------------
Name (time in s)                                     Min                Max               Mean            StdDev             Median               IQR            Outliers     OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 test_perf_sign_psbt_singlesig_wpkh[1]             4.2553 (1.0)       4.2553 (1.0)       4.2553 (1.0)      0.0000 (1.0)       4.2553 (1.0)      0.0000 (1.0)           0;0  0.2350 (1.0)           1           1
 test_perf_sign_psbt_singlesig_pkh[1]              4.7671 (1.12)      4.7671 (1.12)      4.7671 (1.12)     0.0000 (1.0)       4.7671 (1.12)     0.0000 (1.0)           0;0  0.2098 (0.89)          1           1
 test_perf_sign_psbt_singlesig_tr[1]               4.8167 (1.13)      4.8167 (1.13)      4.8167 (1.13)     0.0000 (1.0)       4.8167 (1.13)     0.0000 (1.0)           0;0  0.2076 (0.88)          1           1
 test_perf_sign_psbt_multisig2of3_wsh[1]           6.1687 (1.45)      6.1687 (1.45)      6.1687 (1.45)     0.0000 (1.0)       6.1687 (1.45)     0.0000 (1.0)           0;0  0.1621 (0.69)          1           1
 test_perf_sign_psbt_singlesig_wpkh[3]             8.0682 (1.90)      8.0682 (1.90)      8.0682 (1.90)     0.0000 (1.0)       8.0682 (1.90)     0.0000 (1.0)           0;0  0.1239 (0.53)          1           1
 test_perf_sign_psbt_singlesig_tr[3]               8.6002 (2.02)      8.6002 (2.02)      8.6002 (2.02)     0.0000 (1.0)       8.6002 (2.02)     0.0000 (1.0)           0;0  0.1163 (0.49)          1           1
*test_perf_sign_psbt_tapminiscript_2paths[1]      10.0090 (2.35)     10.0090 (2.35)     10.0090 (2.35)     0.0000 (1.0)      10.0090 (2.35)     0.0000 (1.0)           0;0  0.0999 (0.43)          1           1
 test_perf_sign_psbt_singlesig_pkh[3]             10.0437 (2.36)     10.0437 (2.36)     10.0437 (2.36)     0.0000 (1.0)      10.0437 (2.36)     0.0000 (1.0)           0;0  0.0996 (0.42)          1           1
 test_perf_sign_psbt_multisig3of5_wsh[1]          10.1067 (2.38)     10.1067 (2.38)     10.1067 (2.38)     0.0000 (1.0)      10.1067 (2.38)     0.0000 (1.0)           0;0  0.0989 (0.42)          1           1
 test_perf_sign_psbt_multisig2of3_wsh[3]          12.6187 (2.97)     12.6187 (2.97)     12.6187 (2.97)     0.0000 (1.0)      12.6187 (2.97)     0.0000 (1.0)           0;0  0.0792 (0.34)          1           1
 test_perf_sign_psbt_multisig3of5_wsh[3]          19.5607 (4.60)     19.5607 (4.60)     19.5607 (4.60)     0.0000 (1.0)      19.5607 (4.60)     0.0000 (1.0)           0;0  0.0511 (0.22)          1           1
*test_perf_sign_psbt_tapminiscript_2paths[3]      20.9836 (4.93)     20.9836 (4.93)     20.9836 (4.93)     0.0000 (1.0)      20.9836 (4.93)     0.0000 (1.0)           0;0  0.0477 (0.20)          1           1
 test_perf_sign_psbt_singlesig_wpkh[10]           21.5882 (5.07)     21.5882 (5.07)     21.5882 (5.07)     0.0000 (1.0)      21.5882 (5.07)     0.0000 (1.0)           0;0  0.0463 (0.20)          1           1
 test_perf_sign_psbt_singlesig_tr[10]             22.8121 (5.36)     22.8121 (5.36)     22.8121 (5.36)     0.0000 (1.0)      22.8121 (5.36)     0.0000 (1.0)           0;0  0.0438 (0.19)          1           1
 test_perf_sign_psbt_multisig2of3_wsh[10]         34.0603 (8.00)     34.0603 (8.00)     34.0603 (8.00)     0.0000 (1.0)      34.0603 (8.00)     0.0000 (1.0)           0;0  0.0294 (0.12)          1           1
 test_perf_sign_psbt_singlesig_pkh[10]            44.4550 (10.45)    44.4550 (10.45)    44.4550 (10.45)    0.0000 (1.0)      44.4550 (10.45)    0.0000 (1.0)           0;0  0.0225 (0.10)          1           1
 test_perf_sign_psbt_multisig3of5_wsh[10]         53.3215 (12.53)    53.3215 (12.53)    53.3215 (12.53)    0.0000 (1.0)      53.3215 (12.53)    0.0000 (1.0)           0;0  0.0188 (0.08)          1           1
*test_perf_sign_psbt_tapminiscript_2paths[10]     55.9949 (13.16)    55.9949 (13.16)    55.9949 (13.16)    0.0000 (1.0)      55.9949 (13.16)    0.0000 (1.0)           0;0  0.0179 (0.08)          1           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```


