### PR TITLE
Bump Rust client library to 0.6.2

### DIFF
--- a/bitcoin_client_rs/Cargo.toml
+++ b/bitcoin_client_rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledger_bitcoin_client"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Ledger"]
 edition = "2018"
 description = "Ledger Bitcoin application client"


### PR DESCRIPTION
Technical version bump to re-run the deployment pipeline.

No code changes versus the 0.6.1. Redeploying because the previous deployment is [missing the README.md on crates.io](https://crates.io/crates/ledger_bitcoin_client/0.6.1).