### PR TITLE
Fix and simplify HAVE_SEMIHOSTED_PRINTF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ CFLAGS    += -include debug-helpers/debug.h
 
 ifeq ($(DEBUG),10)
     $(warning Using semihosted PRINTF. Only run with speculos!)
-    DEFINES   += HAVE_PRINTF HAVE_SEMIHOSTED_PRINTF PRINTF=semihosted_printf
+    DEFINES   += HAVE_SEMIHOSTED_PRINTF
 endif
 
 # Needed to be able to include the definition of G_cx

--- a/src/debug-helpers/debug.h
+++ b/src/debug-helpers/debug.h
@@ -7,6 +7,13 @@ void debug_write(const char *buf);
 
 int semihosted_printf(const char *format, ...);
 
+#ifdef HAVE_SEMIHOSTED_PRINTF
+// Route PRINTF to the semihosted implementation, instead of the default one
+// that is routed through seproxyhal.
+#undef PRINTF
+#define PRINTF semihosted_printf
+#endif
+
 void print_stack_pointer(const char *file, int line, const char *func_name);
 
 // Helper macro


### PR DESCRIPTION
It has been broken for a while, and it is still occasionally useful when the standard PRINTF fails.