### PR TITLE
TOML test vectors and unit tests for `get_pubkey`, `register_wallet`, `sign_message`

### DIFF
--- a/test_vectors/README.md
+++ b/test_vectors/README.md
@@ -94,6 +94,11 @@ on navigation, not on the request, and stay as framework-specific code.
   secret-free, checkable by any framework.
 - `expected_wallet_hmac` (hex, 32 bytes, optional): reproducible only with the
   Speculos registration key.
+- `expected_key_types` (array of strings, optional): the per-key classification the
+  device assigns, one entry per key in `@0,@1,…` order. Each is `"internal"` (our key,
+  re-derived and matched), `"external"` (a foreign key, including a fingerprint collision
+  whose re-derived pubkey doesn't match), or `"unspendable"` (the BIP-341 NUMS point).
+  Present only on success cases.
 - *or* `error` (e.g. `INCORRECT_DATA` for a bad name, `NOT_SUPPORTED` for a
   non-sane policy).
 

--- a/test_vectors/README.md
+++ b/test_vectors/README.md
@@ -1,0 +1,130 @@
+# Language-neutral test vectors
+
+This directory holds **TOML test assets** that capture the deterministic core of
+the app's behavioral tests as plain data: inputs and expected outputs/errors,
+with no framework-specific code. The same vectors can be replayed from the Python
+suite (`tests/`), the C unit-tests (`unit-tests/`, via the bundled `tomlc17`
+parser), and — eventually — the Rust client (`bitcoin_client_rs/`).
+
+The goal is to keep the *what the device must produce* separate from the *how a
+given framework drives the device*. UX-only behaviors (screen-by-screen
+approve/reject navigation), randomized PSBTs, multi-round MuSig2, and
+bitcoind-integration end-to-end flows are intentionally **not** captured here;
+they remain as bespoke code in each framework.
+
+All vectors were generated against the Speculos test seed (see
+[`fixtures.toml`](fixtures.toml)) on the **testnet** network.
+
+## Files
+
+| File | Operation |
+|------|-----------|
+| [`fixtures.toml`](fixtures.toml) | Global constants (seed, master fingerprint, network). |
+| [`get_extended_pubkey.toml`](get_extended_pubkey.toml) | `get_extended_pubkey`. |
+| [`sign_message.toml`](sign_message.toml) | `sign_message`. |
+| [`register_wallet.toml`](register_wallet.toml) | `register_wallet`. |
+| [`get_wallet_address.toml`](get_wallet_address.toml) | `get_wallet_address`. |
+| [`sign_psbt.toml`](sign_psbt.toml) | `sign_psbt`. |
+
+## Common conventions
+
+Each file contains an array of `[[case]]` tables.
+
+- **`name`** (string, required, unique): per-case test label.
+- **`description`** (string, optional): human note.
+
+### Wallet policy block
+
+Operations that take a wallet policy (`register_wallet`, `get_wallet_address`,
+`sign_psbt`) embed it directly in the case:
+
+- **`descriptor_template`** (string): a V2 descriptor template, e.g.
+  `"wpkh(@0/**)"`, `"sh(sortedmulti(2,@0/**,@1/**))"`, `"tr(@0/**,pk(@1/**))"`.
+- **`keys_info`** (array of strings): key-info strings in `@0,@1,…` order, e.g.
+  `"[f5acc2fd/44'/1'/0']tpub..."`.
+- **`wallet_name`** (string, optional, default `""`): the registered wallet name.
+  Default (empty) is used for standard single-key policies.
+
+Only **V2** policies are represented (V1 is out of scope). The Python
+`MultisigWallet(...)` helper is just sugar over a `descriptor_template` +
+`keys_info`; vectors always store this canonical form, which both the C parser
+(`parse_descriptor_template`) and the Python `WalletPolicy` accept directly.
+
+### Error encoding
+
+A case that expects the device to reject the request carries an **`error`** string
+instead of the `expected_*` field(s). The value is a symbolic status-word name
+that each framework maps to the numeric status word (see `src/boilerplate/sw.h`
+and `DeviceException.exc` in the Python client):
+
+| Name | Status word |
+|------|-------------|
+| `OK` | `0x9000` |
+| `DENY` | `0x6985` |
+| `SECURITY_STATUS_NOT_SATISFIED` | `0x6982` |
+| `INCORRECT_DATA` | `0x6A80` |
+| `NOT_SUPPORTED` | `0x6A82` |
+| `WRONG_P1P2` | `0x6A86` |
+| `WRONG_DATA_LENGTH` | `0x6A87` |
+| `BAD_STATE` | `0xB007` |
+| `SIGNATURE_FAIL` | `0xB008` |
+
+Only **deterministic** errors (those derivable from the inputs) are encoded here.
+`DENY` errors that arise purely from UI rejection are *not* captured — they depend
+on navigation, not on the request, and stay as framework-specific code.
+
+## Per-operation fields
+
+### `get_extended_pubkey.toml`
+- `path` (string): BIP-32 path, e.g. "m/44'/1'/0'".
+- `standard` (bool): whether the path is exported without user confirmation.
+  - `true`: exported regardless of the display flag.
+  - `false`: exported only when the UI confirmation is shown; otherwise `NOT_SUPPORTED`.
+- `expected_pubkey` (string, optional) on success — *or* `error` (e.g. `NOT_SUPPORTED`,
+  `INCORRECT_DATA`).
+
+### `sign_message.toml`
+- `message` (string) *or* `message_hex` (hex string) for raw/binary input.
+- `path` (string).
+- `expected_signature` (base64 string) on success — *or* `error`.
+
+### `register_wallet.toml`
+- wallet policy block (`descriptor_template`, `keys_info`, `wallet_name`).
+- `expected_wallet_id` (hex, 32 bytes): the policy id (sha256 of the registration);
+  secret-free, checkable by any framework.
+- `expected_wallet_hmac` (hex, 32 bytes, optional): reproducible only with the
+  Speculos registration key.
+- *or* `error` (e.g. `INCORRECT_DATA` for a bad name, `NOT_SUPPORTED` for a
+  non-sane policy).
+
+### `get_wallet_address.toml`
+- wallet policy block.
+- `change` (int): `0` (receive) or `1` (change).
+- `address_index` (int, non-negative).
+- `expected_address` (string) on success — *or* `error`.
+
+### `sign_psbt.toml`
+- `psbt_file` (string, relative to `tests/`) *or* `psbt` (base64 string).
+- wallet policy block.
+- `wallet_hmac` (hex, optional): required for non-default (registered) policies.
+- one or more `[[case.expected_signatures]]` sub-tables:
+  - `input_index` (int).
+  - `pubkey` (hex string): 33-byte compressed (legacy/segwit) or 32-byte x-only
+    (taproot).
+  - `sighash_type` (int, **required**): the SIGHASH flag the input is signed with
+    (`ALL=1`, `NONE=2`, `SINGLE=3`, `+ANYONECANPAY=0x80`; taproot `DEFAULT=0`).
+  - exactly one of:
+    - `signature` (hex string): exact expected bytes. Present for deterministic
+      ECDSA/DER signatures — assert byte-equality. The trailing sighash byte is
+      included for non-default sighash types.
+    - `sighash` (hex string, 32 bytes): the signed message **digest**. Present for
+      taproot Schnorr signatures, which are *not* byte-stable; the framework
+      verifies the produced signature against `pubkey` over this digest (BIP-340).
+      Storing the digest directly keeps verification portable — a framework need
+      not reimplement the sighash algorithm. (For a 65-byte taproot signature, drop
+      the trailing sighash-type byte before verifying.)
+  - `tapleaf_hash` (hex string, optional): for tapscript spends.
+
+The top-level case may also carry `error` (instead of `expected_signatures`) for
+deterministic rejections, e.g. `NOT_SUPPORTED` for `SIGHASH_SINGLE` with no
+matching output, or an unsupported sighash type.

--- a/test_vectors/README.md
+++ b/test_vectors/README.md
@@ -19,12 +19,12 @@ All vectors were generated against the Speculos test seed (see
 
 | File | Operation |
 |------|-----------|
-| [`fixtures.toml`](fixtures.toml) | Global constants (seed, master fingerprint, network). |
-| [`get_extended_pubkey.toml`](get_extended_pubkey.toml) | `get_extended_pubkey`. |
-| [`sign_message.toml`](sign_message.toml) | `sign_message`. |
-| [`register_wallet.toml`](register_wallet.toml) | `register_wallet`. |
-| [`get_wallet_address.toml`](get_wallet_address.toml) | `get_wallet_address`. |
-| [`sign_psbt.toml`](sign_psbt.toml) | `sign_psbt`. |
+| [`fixtures.toml`](fixtures.toml) | Global constants (seed, master fingerprint, network) |
+| [`get_extended_pubkey.toml`](get_extended_pubkey.toml) | `get_extended_pubkey` |
+| [`sign_message.toml`](sign_message.toml) | `sign_message` |
+| [`register_wallet.toml`](register_wallet.toml) | `register_wallet` |
+| [`get_wallet_address.toml`](get_wallet_address.toml) | `get_wallet_address` |
+| [`sign_psbt.toml`](sign_psbt.toml) | `sign_psbt` |
 
 ## Common conventions
 

--- a/test_vectors/README.md
+++ b/test_vectors/README.md
@@ -84,9 +84,13 @@ on navigation, not on the request, and stay as framework-specific code.
   `INCORRECT_DATA`).
 
 ### `sign_message.toml`
-- `message` (string) *or* `message_hex` (hex string) for raw/binary input.
+- `message` (string): UTF-8 text to sign.
 - `path` (string).
 - `expected_signature` (base64 string) on success — *or* `error`.
+- `displayed_as` (string, optional): how the device shows the message on the
+  confirmation screen — `"message"` (the text itself, for printable messages up to
+  10 lines) or `"hash"` (the uppercase hex of `sha256(message)`, for non-printable or
+  over-long messages). Present only on success cases.
 
 ### `register_wallet.toml`
 - wallet policy block (`descriptor_template`, `keys_info`, `wallet_name`).

--- a/test_vectors/fixtures.toml
+++ b/test_vectors/fixtures.toml
@@ -1,0 +1,14 @@
+# Global constants the vectors in this directory were generated against.
+#
+# Frameworks that re-derive keys/signatures from the seed read these once.
+# These match tests/conftest.py (the Speculos test setup).
+
+# The Speculos test seed (BIP-39 mnemonic).
+mnemonic = "glory promote mansion idle axis finger extra february uncover one trip resource lawn turtle enact monster seven myth punch hobby comfort wild raise skin"
+
+# Master key fingerprint derived from the seed above (BIP-32, 4 bytes, hex).
+master_key_fingerprint = "f5acc2fd"
+
+# Network all expected addresses/keys are encoded for.
+# testnet: base58 P2PKH version 111, P2SH version 196; bech32/bech32m HRP "tb".
+network = "test"

--- a/test_vectors/get_extended_pubkey.toml
+++ b/test_vectors/get_extended_pubkey.toml
@@ -1,0 +1,211 @@
+# Test vectors for get_extended_pubkey.
+#
+# Source: tests/test_get_extended_pubkey.py
+#
+# Schema (per [[case]]):
+#   name      human-readable identifier.
+#   path      BIP32 derivation path ("m", "m/44'/1'/0'", ...).
+#   standard  whether the path is exported without user confirmation:
+#               * standard = true  -> exported regardless of the display flag.
+#               * standard = false -> only exported with display = true; with
+#                                     display = false it is rejected with
+#                                     NOT_SUPPORTED.
+#   error     (optional) expected status word name. Orthogonal to `standard`:
+#             when set, that error is expected instead of a successful export
+#             (e.g. paths over the max depth give INCORRECT_DATA regardless of
+#             the display flag).
+#   expected_pubkey
+#             (optional) expected base58check pubkey. Only pinned where an
+#             independent source exists (the functional tests). When omitted,
+#             the test only checks that the export succeeds; the encoding
+#             itself is covered by the pinned cases.
+#
+# Pure UI approve/reject flows and raw-APDU parse errors are not captured here.
+
+
+# ---- Standard paths (exported with or without display) ----
+
+[[case]]
+name = "std_pkh_account0"
+path = "m/44'/1'/0'"
+standard = true
+expected_pubkey = "tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT"
+
+[[case]]
+name = "std_pkh_account10"
+path = "m/44'/1'/10'"
+standard = true
+expected_pubkey = "tpubDCwYjpDhUdPGp21gSpVay2QPJVh6WNySWMXPhbcu1DsxH31dF7mY18oibbu5RxCLBc1Szerjscuc3D5HyvfYqfRvc9mesewnFqGmPjney4d"
+
+[[case]]
+name = "std_pkh_account2_recv_42"
+path = "m/44'/1'/2'/1/42"
+standard = true
+expected_pubkey = "tpubDGF9YgHKv6qh777rcqVhpmDrbNzgophJM9ec7nHiSfrbss7fVBXoqhmZfohmJSvhNakDHAspPHjVVNL657tLbmTXvSeGev2vj5kzjMaeupT"
+
+[[case]]
+name = "std_bip48_account4"
+path = "m/48'/1'/4'/1'/0/7"
+standard = true
+expected_pubkey = "tpubDK8WPFx4WJo1R9mEL7Wq325wBiXvkAe8ipgb9Q1QBDTDUD2YeCfutWtzY88NPokZqJyRPKHLGwTNLT7jBG59aC6VH8q47LDGQitPB6tX2d7"
+
+[[case]]
+name = "std_sh_wpkh_account1"
+path = "m/49'/1'/1'/1/3"
+standard = true
+expected_pubkey = "tpubDGnetmJDCL18TyaaoyRAYbkSE9wbHktSdTS4mfsR6inC8c2r6TjdBt3wkqEQhHYPtXpa46xpxDaCXU2PRNUGVvDzAHPG6hHRavYbwAGfnFr"
+
+[[case]]
+name = "std_wpkh_account2"
+path = "m/84'/1'/2'/0/10"
+standard = true
+expected_pubkey = "tpubDG9YpSUwScWJBBSrhnAT47NcT4NZGLcY18cpkaiWHnkUCi19EtCh8Heeox268NaFF6o56nVeSXuTyK6jpzTvV1h68Kr3edA8AZp27MiLUNt"
+
+[[case]]
+name = "std_tr_account4"
+path = "m/86'/1'/4'/1/12"
+standard = true
+expected_pubkey = "tpubDHTZ815MvTaRmo6Qg1rnU6TEU4ZkWyA56jA1UgpmMcBGomnSsyo34EZLoctzZY9MTJ6j7bhccceUeXZZLxZj5vgkVMYfcZ7DNPsyRdFpS3f"
+
+[[case]]
+name = "std_tr_8_steps"
+path = "m/86'/1'/4'/1/2/3/4/5"
+standard = true
+expected_pubkey = "tpubDNcjumrTe1BBYEc1FmMaJZQw47mbvb4LfX4YwqC6GQ18PfMfuH3BEYREfdHm2gWXkSJ3JiXHF11iKnbJxzxp5qkgo8BBy2L48FRvrLhpTuh"
+
+[[case]]
+name = "std_bip45_unchained_account0"
+path = "m/45'/1'/0'"
+standard = true
+expected_pubkey = "tpubDCy2BKyxJFzACNgThkunvdnkHNotREK9LQDw8L9J1gx26SyzfoeJynJgWekzkramggmahVAgeHPxfpnvFtJ7hcYADrsVUnsPSei2tY9fBLL"
+
+[[case]]
+name = "std_bip45_unchained_account0_chain1"
+path = "m/45'/1'/0'/1"
+standard = true
+expected_pubkey = "tpubDFGDxRGdGFKekUtPuta4p9Kw2a2PSeyyhSTa7KNENJfBuJ78EEsL1LxwAA8ddSxZFWBT9gYRuLDoa2rwdix56WRsq77vAJ2iqeyPw6UBeyt"
+
+# Electrum historically used "m/4541509h/1112098098h" to derive encryption
+# keys, so the app whitelists it: non-standard in the BIP sense, but exported
+# without confirmation.
+[[case]]
+name = "electrum_path"
+path = "m/4541509'/1112098098'"
+standard = true
+expected_pubkey = "tpubDAs3mrkQXkGyzp7Yo9SXiZNW7Tmia5EmdUpXjuBQvBDDGGr9CnVHehSB6P5RZFY3bwkYBweXir8MhmvPXqYHHVxKrFkm3mfZ5UkjG5ZH8Ui"
+
+# Boundary: account == MAX_BIP44_ACCOUNT_RECOMMENDED (100) is still standard.
+[[case]]
+name = "std_account_max"
+path = "m/44'/1'/100'"
+standard = true
+
+# Boundary: BIP48 script type 2' is a standardized value, so this is standard.
+[[case]]
+name = "std_bip48_script_type_2"
+path = "m/48'/1'/0'/2'"
+standard = true
+
+
+# ---- Non-standard paths (exported only with display = true) ----
+
+# Unchained Capital multisig setup. Non-standard for export-without-display:
+# is_path_safe accepts BIP-45 only in the canonical m/45'/coin_type'/account'
+# shape (3 hardened steps, extras unhardened, coin_type == BIP44_COIN_TYPE).
+# This path has a 4th hardened step (1') and coin_type 2', so it is only
+# exported with display = true. (Derivation itself is still permitted; the
+# Makefile whitelists the whole 45' tree via PATH_APP_LOAD_PARAMS.)
+[[case]]
+name = "nonstd_bip45_unchained"
+path = "m/45'/2'/0'/1'"
+standard = false
+expected_pubkey = "tpubDFL11pFAgsKed5bv9Tkxe51xyB4qo1cPDwK6c8WZ4wiVEjtGDg5YuMXNk9yZcB6b47k2oaSWADJF3CRmk97qAwnaiRieT2ocWzh4rq2b3F3"
+
+[[case]]
+name = "nonstandard_bip45_root_display"
+path = "m/45'"
+standard = false
+expected_pubkey = "tpubDA4runSouWhEn4C36dL1PwpMhWi1LCgc7EkYJXLExjVr3eWNE5p5ZRUe7LN7cY8YwCroQsLECcv9ufij8EUpDHM2WQM9Cba8Ztf6Zo8jpFf"
+
+# Maximum supported depth (10 steps). Non-standard: it has hardened steps
+# beyond the BIP48 prefix, so it is only exported when display = true.
+[[case]]
+name = "bip48_max_depth_display"
+path = "m/48'/1'/0'/2'/0'/1'/2'/3'/0/1"
+standard = false
+expected_pubkey = "tpubDSegeM6ezY6VYgNjYiUxk94ZwLYeuUzHpUYff4LLdEEUVUd8VpgGUxyxZ9oRiEepZzmFZogVWFEWznRj3oJgEuWjcg6BERCxTCYdaxwtShk"
+
+[[case]]
+name = "nonstd_root"
+path = "m"
+standard = false
+
+[[case]]
+name = "nonstd_purse_only"
+path = "m/44'"
+standard = false
+
+[[case]]
+name = "nonstd_purpose_coin"
+path = "m/44'/1'"
+standard = false
+
+[[case]]
+name = "nonstd_wrong_coin_type"
+path = "m/44'/10'/0'"
+standard = false
+
+[[case]]
+name = "nonstd_account_not_hardened"
+path = "m/44'/1'/0"
+standard = false
+
+[[case]]
+name = "nonstd_cointype_not_hardened"
+path = "m/44'/1/0'"
+standard = false
+
+[[case]]
+name = "nonstd_purpose_not_hardened"
+path = "m/44/1'/0'"
+standard = false
+
+[[case]]
+name = "nonstd_bip48_script_type_0"
+path = "m/48'/1'/0'/0'"
+standard = false
+
+[[case]]
+name = "nonstd_bip48_script_type_3"
+path = "m/48'/1'/0'/3'"
+standard = false
+
+[[case]]
+name = "nonstd_unknown_purpose"
+path = "m/999'/1'/0'"
+standard = false
+
+[[case]]
+name = "nonstd_bip45_wrong_coin_type"
+path = "m/45'/2'/0'"
+standard = false
+
+[[case]]
+name = "nonstd_bip45_too_short"
+path = "m/45'/1'"
+standard = false
+
+# Boundary: account == MAX_BIP44_ACCOUNT_RECOMMENDED + 1 (101) is non-standard.
+[[case]]
+name = "nonstd_account_over_max"
+path = "m/44'/1'/101'"
+standard = false
+
+
+# ---- Path exceeding the maximum depth: INCORRECT_DATA (regardless of display) ----
+
+[[case]]
+name = "too_long_path"
+path = "m/48'/1'/0'/2'/0'/1'/2'/3'/0/1/2"
+standard = true
+error = "INCORRECT_DATA"

--- a/test_vectors/get_wallet_address.toml
+++ b/test_vectors/get_wallet_address.toml
@@ -1,13 +1,9 @@
-# Test vectors for get_wallet_script + get_script_address.
+# Test vectors for get_wallet_address (get_wallet_script + get_script_address).
 #
-# Each test case is a `[[case]]` entry with the following keys:
-#   name              - human-readable label
-#   descriptor_template - the V2 descriptor template
-#   keys_info         - list of key info strings, in the order referenced
-#                       by @0, @1, ...
-#   change            - 0 (receive) or 1 (change)
-#   address_index     - non-negative integer
-#   expected_address  - the address the device must produce
+# Schema and conventions are documented in test_vectors/README.md. In short, each
+# `[[case]]` carries a wallet policy block (descriptor_template, keys_info,
+# optional wallet_name), a `change` flag (0 receive / 1 change), an
+# `address_index`, and the `expected_address` (or an `error` name).
 #
 # Vectors below are taken from tests/test_get_wallet_address.py.
 # All segwit addresses use the "tb" HRP (testnet); base58 versions are

--- a/test_vectors/register_wallet.toml
+++ b/test_vectors/register_wallet.toml
@@ -19,6 +19,7 @@ keys_info = [
 wallet_name = "Cold storage"
 expected_wallet_id = "1d150ed425a871a5ca7e2c55db1b3295c1fd97147fd0a7b188d4327f4ba7402a"
 expected_wallet_hmac = "fa73e36119324fbe4cc1ca94aa842c6261526d44112a22164bc57c3335102b04"
+expected_key_types = ["external", "internal"]
 
 [[case]]
 name = "multisig_sh_wit_2of2"
@@ -31,6 +32,7 @@ keys_info = [
 wallet_name = "Cold storage"
 expected_wallet_id = "763926f53be53ad89a9248dc15bc2f3ed577a59a87d81cd88f14279b263b31f6"
 expected_wallet_hmac = "1f498e7444841b883c4a63e2b88a5cad297c289d235794f8e3e17cf559ed0654"
+expected_key_types = ["external", "internal"]
 
 [[case]]
 name = "multisig_wit_2of2"
@@ -43,6 +45,7 @@ keys_info = [
 wallet_name = "Cold storage"
 expected_wallet_id = "cd9474ae9e74403128477789789db43a215e996af80d60120f0d844f8404ac64"
 expected_wallet_hmac = "d7c7a60b4ab4a14c1bf8901ba627d72140b2fb907f2b4e35d2e693bce9fbb371"
+expected_key_types = ["external", "internal"]
 
 [[case]]
 name = "multisig_wit_2of2_long_name"
@@ -55,6 +58,7 @@ keys_info = [
 wallet_name = "Cold storage with a pretty long name that requires 64 characters"
 expected_wallet_id = "57f64b36153b819c624dedd0ba3ba491000c41652087b5b265b2460508b09620"
 expected_wallet_hmac = "42ea7900175227ee3ea259a0a061dda232dce3e93707d0940f9dc63bab50d35a"
+expected_key_types = ["external", "internal"]
 
 [[case]]
 name = "unusual_singlesig_legacy"
@@ -66,6 +70,7 @@ keys_info = [
 wallet_name = "Unusual legacy"
 expected_wallet_id = "409d4fb1e165e94fb7a822f82ce648e3cc263f06311b790d7f6299ee7fcb5987"
 expected_wallet_hmac = "5d4a77a905b1be578a638f5c037a9a646af5ad71c16f813913bb9aba7abac795"
+expected_key_types = ["internal"]
 
 [[case]]
 name = "unusual_singlesig_nested_segwit"
@@ -77,6 +82,7 @@ keys_info = [
 wallet_name = "Unusual nested_segwit"
 expected_wallet_id = "70e97d1e974a5cf46cd13b8c3358850c51873a1a1ab8b60647ed35520a76e870"
 expected_wallet_hmac = "f7e49a379e71cfe6645a564c641f1b5232aeb6696c862f4f3df581236bd451c4"
+expected_key_types = ["internal"]
 
 [[case]]
 name = "unusual_singlesig_native_segwit"
@@ -88,6 +94,7 @@ keys_info = [
 wallet_name = "Unusual native_segwit"
 expected_wallet_id = "d5de0973b368d69f67166391d66b8ead31478a6e7dda5c9acbeff185523e1f64"
 expected_wallet_hmac = "b9c66ce0adb1684c2f2cf51e280c3a95746393ddfe32ebfb6938922a37b438d9"
+expected_key_types = ["internal"]
 
 [[case]]
 name = "unusual_singlesig_taproot"
@@ -99,6 +106,7 @@ keys_info = [
 wallet_name = "Unusual taproot"
 expected_wallet_id = "4e9679b3f4aaf54a3ffdef160963bc5b4d6ac706499d2317e8514819a9777921"
 expected_wallet_hmac = "9006e41fe8ba29dd93aeae79dc6b3513db42d2fbcf18dbda5df860342e137fec"
+expected_key_types = ["internal"]
 
 [[case]]
 name = "miniscript_long_policy"
@@ -112,6 +120,7 @@ keys_info = [
 wallet_name = "Long policy"
 expected_wallet_id = "71b806a6ef8102626f8c9126a0bac51efca19fadd295c42245be240138bb0b57"
 expected_wallet_hmac = "c018966ba0416569d3510c93f5c6cd88c4338a9192e3de3a94db9d27f58615b3"
+expected_key_types = ["internal", "external", "external"]
 
 [[case]]
 name = "miniscript_minmax_relative_timelocks"
@@ -125,6 +134,7 @@ keys_info = [
 wallet_name = "Relative timelocks"
 expected_wallet_id = "3d9900113d87d80c72ca9d036d1f7aa163cea194629afa4c4946409e05b00fcb"
 expected_wallet_hmac = "65fda496184f9f720c2d3eb47169b94d2390fe2a085e6d2c43eb6d12d7608af3"
+expected_key_types = ["internal", "external", "external"]
 
 [[case]]
 name = "tr_script_pk"
@@ -137,6 +147,7 @@ keys_info = [
 wallet_name = "Taproot foreign internal key, and our script key"
 expected_wallet_id = "ba1a89c470ab0c36c38beaebb577b754c33d90b51df53977e2b01018fbe25f33"
 expected_wallet_hmac = "dae925660e20859ed8833025d46444483ce264fdb77e34569aabe9d590da8fb7"
+expected_key_types = ["external", "internal"]
 
 [[case]]
 name = "tr_nums_keypath"
@@ -149,6 +160,7 @@ keys_info = [
 wallet_name = "Taproot unspendable keypath"
 expected_wallet_id = "ba6c11196b604c062a27e195bcbdfe6c1fe1fa61e92256974b5c53c2fc2e2172"
 expected_wallet_hmac = "7af8844fb3f176337acd66fb76113b5e250e1be75a0845964587219b297fda59"
+expected_key_types = ["unspendable", "internal"]
 
 [[case]]
 name = "tr_script_sortedmulti_a"
@@ -162,6 +174,7 @@ keys_info = [
 wallet_name = "Taproot single-key or multisig 2-of-2"
 expected_wallet_id = "46c498a049e164ec7feaf167c3ae0f4282217645a338f66f5377bfe67f6a8aa0"
 expected_wallet_hmac = "a3f31e9d7b70d1d967413488bae136a8b6c7afd1de0524deb6cf74f5c509b9ab"
+expected_key_types = ["internal", "external", "internal"]
 
 [[case]]
 name = "max_derivation_steps"
@@ -173,6 +186,7 @@ keys_info = [
 wallet_name = "Max derivation"
 expected_wallet_id = "71b58446a17ebc98e654560f4f1fb9003bad49ddde1d3ee9384221f7f2d3dda2"
 expected_wallet_hmac = "e3bb8a13e19d74079ee209a99438da0b47f3f430a88130ba18b1c05e626d22c8"
+expected_key_types = ["internal"]
 
 # ---- Deterministic rejections ----
 
@@ -374,4 +388,17 @@ keys_info = [
 ]
 wallet_name = "Fingerprint collision"
 error = "INCORRECT_DATA"
+
+[[case]]
+name = "internal_key_with_collision"
+description = "1-of-2 with a fingerprint-collision key (our fp, foreign xpub) plus a real internal key; the collision key must still be classified external"
+descriptor_template = "wsh(multi(1,@0/**,@1/**))"
+keys_info = [
+    "[f5acc2fd/44'/1'/3']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF",
+    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+]
+wallet_name = "Collision and internal"
+expected_wallet_id = "25bbdfdbc7d7f184ddbea79d52bd1235d95cce799d06b4e7aced22b253d4e266"
+expected_wallet_hmac = "f82f318bdd7d7db9f586b34c2f4985614ec9abf0d9c9ef48b3e57ba246ef0cf2"
+expected_key_types = ["external", "internal"]
 

--- a/test_vectors/register_wallet.toml
+++ b/test_vectors/register_wallet.toml
@@ -1,0 +1,377 @@
+# Test vectors for register_wallet.
+#
+# Schema and conventions are documented in test_vectors/README.md.
+# Source: tests/test_register_wallet.py
+#
+# `expected_wallet_id` is the policy id (sha256 of the registration) and can be
+# checked by any framework with no secrets. `expected_wallet_hmac` is the device
+# HMAC over that id, reproducible only with the Speculos registration key
+# (see fixtures.toml). Pure UI reject flows (DENY) are not captured here.
+
+[[case]]
+name = "multisig_legacy_2of2"
+description = "2-of-2 sortedmulti, legacy P2SH"
+descriptor_template = "sh(sortedmulti(2,@0/**,@1/**))"
+keys_info = [
+    "[5c9e228d/48'/1'/0'/0']tpubDEGquuorgFNb8bjh5kNZQMPtABJzoWwNm78FUmeoPkfRtoPF7JLrtoZeT3J3ybq1HmC3Rn1Q8wFQ8J5usanzups5rj7PJoQLNyvq8QbJruW",
+    "[f5acc2fd/48'/1'/0'/0']tpubDFAqEGNyad35WQAZMmPD4vgBXnjH16RGciLdWekPe4f4d5JzoHVu1PS86Sy4Tm63vDf8rfV3UjifhrRuSUDfiZj5KPffTPyZ4ZXBKvjD8jm",
+]
+wallet_name = "Cold storage"
+expected_wallet_id = "1d150ed425a871a5ca7e2c55db1b3295c1fd97147fd0a7b188d4327f4ba7402a"
+expected_wallet_hmac = "fa73e36119324fbe4cc1ca94aa842c6261526d44112a22164bc57c3335102b04"
+
+[[case]]
+name = "multisig_sh_wit_2of2"
+description = "2-of-2 sortedmulti, wrapped segwit P2SH-P2WSH"
+descriptor_template = "sh(wsh(sortedmulti(2,@0/**,@1/**)))"
+keys_info = [
+    "[76223a6e/48'/1'/0'/1']tpubDE7NQymr4AFtcJXi9TaWZtrhAdy8QyKmT4U6b9qYByAxCzoyMJ8zw5d8xVLVpbTRAEqP8pVUxjLE2vDt1rSFjaiS8DSz1QcNZ8D1qxUMx1g",
+    "[f5acc2fd/48'/1'/0'/1']tpubDFAqEGNyad35YgH8zxvxFZqNUoPtr5mDojs7wzbXQBHTZ4xHeVXG6w2HvsKvjBpaRpTmjYDjdPg5w2c6Wvu8QBkyMDrmBWdCyqkDM7reSsY",
+]
+wallet_name = "Cold storage"
+expected_wallet_id = "763926f53be53ad89a9248dc15bc2f3ed577a59a87d81cd88f14279b263b31f6"
+expected_wallet_hmac = "1f498e7444841b883c4a63e2b88a5cad297c289d235794f8e3e17cf559ed0654"
+
+[[case]]
+name = "multisig_wit_2of2"
+description = "2-of-2 sortedmulti, native segwit P2WSH"
+descriptor_template = "wsh(sortedmulti(2,@0/**,@1/**))"
+keys_info = [
+    "[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF",
+    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+]
+wallet_name = "Cold storage"
+expected_wallet_id = "cd9474ae9e74403128477789789db43a215e996af80d60120f0d844f8404ac64"
+expected_wallet_hmac = "d7c7a60b4ab4a14c1bf8901ba627d72140b2fb907f2b4e35d2e693bce9fbb371"
+
+[[case]]
+name = "multisig_wit_2of2_long_name"
+description = "2-of-2 native segwit with a 64-char name"
+descriptor_template = "wsh(sortedmulti(2,@0/**,@1/**))"
+keys_info = [
+    "[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF",
+    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+]
+wallet_name = "Cold storage with a pretty long name that requires 64 characters"
+expected_wallet_id = "57f64b36153b819c624dedd0ba3ba491000c41652087b5b265b2460508b09620"
+expected_wallet_hmac = "42ea7900175227ee3ea259a0a061dda232dce3e93707d0940f9dc63bab50d35a"
+
+[[case]]
+name = "unusual_singlesig_legacy"
+description = "single-key legacy on an unusual account path (44'/1'/3')"
+descriptor_template = "pkh(@0/**)"
+keys_info = [
+    "[f5acc2fd/44'/1'/3']tpubDCwYjpDhUdPGW815u9VExvLRXDAHehcnkNfjqiwSvJp7NizpAGsX3Qfq9A173rES9vF17HgeqXBUvodRTyeTHCeAvg7gVgDE19mudggheN1",
+]
+wallet_name = "Unusual legacy"
+expected_wallet_id = "409d4fb1e165e94fb7a822f82ce648e3cc263f06311b790d7f6299ee7fcb5987"
+expected_wallet_hmac = "5d4a77a905b1be578a638f5c037a9a646af5ad71c16f813913bb9aba7abac795"
+
+[[case]]
+name = "unusual_singlesig_nested_segwit"
+description = "single-key nested_segwit on an unusual account path (44'/1'/3')"
+descriptor_template = "sh(wpkh(@0/**))"
+keys_info = [
+    "[f5acc2fd/44'/1'/3']tpubDCwYjpDhUdPGW815u9VExvLRXDAHehcnkNfjqiwSvJp7NizpAGsX3Qfq9A173rES9vF17HgeqXBUvodRTyeTHCeAvg7gVgDE19mudggheN1",
+]
+wallet_name = "Unusual nested_segwit"
+expected_wallet_id = "70e97d1e974a5cf46cd13b8c3358850c51873a1a1ab8b60647ed35520a76e870"
+expected_wallet_hmac = "f7e49a379e71cfe6645a564c641f1b5232aeb6696c862f4f3df581236bd451c4"
+
+[[case]]
+name = "unusual_singlesig_native_segwit"
+description = "single-key native_segwit on an unusual account path (44'/1'/3')"
+descriptor_template = "wpkh(@0/**)"
+keys_info = [
+    "[f5acc2fd/44'/1'/3']tpubDCwYjpDhUdPGW815u9VExvLRXDAHehcnkNfjqiwSvJp7NizpAGsX3Qfq9A173rES9vF17HgeqXBUvodRTyeTHCeAvg7gVgDE19mudggheN1",
+]
+wallet_name = "Unusual native_segwit"
+expected_wallet_id = "d5de0973b368d69f67166391d66b8ead31478a6e7dda5c9acbeff185523e1f64"
+expected_wallet_hmac = "b9c66ce0adb1684c2f2cf51e280c3a95746393ddfe32ebfb6938922a37b438d9"
+
+[[case]]
+name = "unusual_singlesig_taproot"
+description = "single-key taproot on an unusual account path (44'/1'/3')"
+descriptor_template = "tr(@0/**)"
+keys_info = [
+    "[f5acc2fd/44'/1'/3']tpubDCwYjpDhUdPGW815u9VExvLRXDAHehcnkNfjqiwSvJp7NizpAGsX3Qfq9A173rES9vF17HgeqXBUvodRTyeTHCeAvg7gVgDE19mudggheN1",
+]
+wallet_name = "Unusual taproot"
+expected_wallet_id = "4e9679b3f4aaf54a3ffdef160963bc5b4d6ac706499d2317e8514819a9777921"
+expected_wallet_hmac = "9006e41fe8ba29dd93aeae79dc6b3513db42d2fbcf18dbda5df860342e137fec"
+
+[[case]]
+name = "miniscript_long_policy"
+description = "miniscript policy longer than 256 bytes"
+descriptor_template = "wsh(and_v(and_v(v:pk(@0/**),or_c(pk(@1/**),or_c(pk(@2/**),v:older(1000)))),and_v(v:hash256(0563fb3e85cbc61b134941ad6610a2b0dfd77543dfb77a5433ff3cb538213807),and_v(v:hash256(ad3391a00bad00a6a03f907b3fcc2f369a88be038c63c7db7f43b01e097efbbe),hash256(137dfa9b54a538200c94e3c9dd1a59b431e3b89aef8093fc910df48a98cb06d9)))))"
+keys_info = [
+    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+    "tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF",
+    "tpubDDV6FDLcCieWUeN7R3vZK2Qs3KuQed3ScTY9EiwMXvyCkLjDbCb8RXaAgWDbkG4tW1BMKVF1zERHnyt78QKd4ZaAYGMJMpvHPwgSSU1AxZ3",
+]
+wallet_name = "Long policy"
+expected_wallet_id = "71b806a6ef8102626f8c9126a0bac51efca19fadd295c42245be240138bb0b57"
+expected_wallet_hmac = "c018966ba0416569d3510c93f5c6cd88c4338a9192e3de3a94db9d27f58615b3"
+
+[[case]]
+name = "miniscript_minmax_relative_timelocks"
+description = "min/max relative timelocks in a taptree"
+descriptor_template = "tr(@0/<0;1>/*,{thresh(3,pk(@0/<2;3>/*),s:pk(@1/<2;3>/*),s:pk(@2/<2;3>/*),sln:older(1),sln:older(65535)),thresh(3,pk(@0/<4;5>/*),s:pk(@1/<4;5>/*),s:pk(@2/<4;5>/*),sln:older(4194305),sln:older(4259839))})"
+keys_info = [
+    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+    "tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF",
+    "tpubDDV6FDLcCieWUeN7R3vZK2Qs3KuQed3ScTY9EiwMXvyCkLjDbCb8RXaAgWDbkG4tW1BMKVF1zERHnyt78QKd4ZaAYGMJMpvHPwgSSU1AxZ3",
+]
+wallet_name = "Relative timelocks"
+expected_wallet_id = "3d9900113d87d80c72ca9d036d1f7aa163cea194629afa4c4946409e05b00fcb"
+expected_wallet_hmac = "65fda496184f9f720c2d3eb47169b94d2390fe2a085e6d2c43eb6d12d7608af3"
+
+[[case]]
+name = "tr_script_pk"
+description = "taproot, foreign internal key and our script key"
+descriptor_template = "tr(@0/**,pk(@1/**))"
+keys_info = [
+    "[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF",
+    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+]
+wallet_name = "Taproot foreign internal key, and our script key"
+expected_wallet_id = "ba1a89c470ab0c36c38beaebb577b754c33d90b51df53977e2b01018fbe25f33"
+expected_wallet_hmac = "dae925660e20859ed8833025d46444483ce264fdb77e34569aabe9d590da8fb7"
+
+[[case]]
+name = "tr_nums_keypath"
+description = "taproot with an unspendable (NUMS) internal key"
+descriptor_template = "tr(@0/**,pk(@1/**))"
+keys_info = [
+    "tpubD6NzVbkrYhZ4WLczPJWReQycCJdd6YVWXubbVUFnJ5KgU5MDQrD998ZJLSmaB7GVcCnJSDWprxmrGkJ6SvgQC6QAffVpqSvonXmeizXcrkN",
+    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+]
+wallet_name = "Taproot unspendable keypath"
+expected_wallet_id = "ba6c11196b604c062a27e195bcbdfe6c1fe1fa61e92256974b5c53c2fc2e2172"
+expected_wallet_hmac = "7af8844fb3f176337acd66fb76113b5e250e1be75a0845964587219b297fda59"
+
+[[case]]
+name = "tr_script_sortedmulti_a"
+description = "taproot single-key or 2-of-2 sortedmulti_a script"
+descriptor_template = "tr(@0/**,sortedmulti_a(2,@1/**,@2/**))"
+keys_info = [
+    "[f5acc2fd/48'/1'/0'/1']tpubDFAqEGNyad35YgH8zxvxFZqNUoPtr5mDojs7wzbXQBHTZ4xHeVXG6w2HvsKvjBpaRpTmjYDjdPg5w2c6Wvu8QBkyMDrmBWdCyqkDM7reSsY",
+    "[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF",
+    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+]
+wallet_name = "Taproot single-key or multisig 2-of-2"
+expected_wallet_id = "46c498a049e164ec7feaf167c3ae0f4282217645a338f66f5377bfe67f6a8aa0"
+expected_wallet_hmac = "a3f31e9d7b70d1d967413488bae136a8b6c7afd1de0524deb6cf74f5c509b9ab"
+
+[[case]]
+name = "max_derivation_steps"
+description = "key with the maximum (8) BIP-388 derivation steps"
+descriptor_template = "wpkh(@0/**)"
+keys_info = [
+    "[f5acc2fd/48'/1'/0'/2'/0'/1'/2'/3']tpubDNTK3WZ6g6eZBbCYCdFMpkCNvEqMxYexWRyqrGDkC5WDsNJdUk95z9wHWm6rBZeeMRxKafnuJzT8TqUs94A11KKkW9wT1pcFQShC9p3Vcxi",
+]
+wallet_name = "Max derivation"
+expected_wallet_id = "71b58446a17ebc98e654560f4f1fb9003bad49ddde1d3ee9384221f7f2d3dda2"
+expected_wallet_hmac = "e3bb8a13e19d74079ee209a99438da0b47f3f430a88130ba18b1c05e626d22c8"
+
+# ---- Deterministic rejections ----
+
+[[case]]
+name = "invalid_pubkey_version"
+description = "external key uses a mainnet xpub version instead of testnet tpub"
+descriptor_template = "wsh(sortedmulti(2,@0/**,@1/**))"
+keys_info = [
+    "[76223a6e/48'/1'/0'/2']xpub6DjjtjxALtJSP9dKRKuhejeTpZc711gUGZyS9nCM5GAtrNTDuMBZD2FcndJoHst6LYNbJktm4NmJyKqspLi5uRmtnDMAdcPAf2jiSj9gFTX",
+    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+]
+wallet_name = "Cold storage"
+error = "INCORRECT_DATA"
+
+[[case]]
+name = "invalid_name_empty"
+description = "unacceptable wallet name: empty"
+descriptor_template = "wsh(sortedmulti(2,@0/**,@1/**))"
+keys_info = [
+    "[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF",
+    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+]
+error = "INCORRECT_DATA"
+
+[[case]]
+name = "invalid_name_too_long_65"
+description = "unacceptable wallet name: too_long_65"
+descriptor_template = "wsh(sortedmulti(2,@0/**,@1/**))"
+keys_info = [
+    "[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF",
+    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+]
+wallet_name = "This wallet name is much too long since it requires 65 characters"
+error = "INCORRECT_DATA"
+
+[[case]]
+name = "invalid_name_leading_space"
+description = "unacceptable wallet name: leading_space"
+descriptor_template = "wsh(sortedmulti(2,@0/**,@1/**))"
+keys_info = [
+    "[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF",
+    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+]
+wallet_name = " Test"
+error = "INCORRECT_DATA"
+
+[[case]]
+name = "invalid_name_trailing_space"
+description = "unacceptable wallet name: trailing_space"
+descriptor_template = "wsh(sortedmulti(2,@0/**,@1/**))"
+keys_info = [
+    "[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF",
+    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+]
+wallet_name = "Test "
+error = "INCORRECT_DATA"
+
+[[case]]
+name = "invalid_name_out_of_range_char"
+description = "unacceptable wallet name: out_of_range_char"
+descriptor_template = "wsh(sortedmulti(2,@0/**,@1/**))"
+keys_info = [
+    "[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF",
+    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+]
+wallet_name = "Tæst"
+error = "INCORRECT_DATA"
+
+[[case]]
+name = "missing_key"
+description = "policy references @1 but only one key is provided"
+descriptor_template = "wsh(multi(2,@0/**,@1/**))"
+keys_info = [
+    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+]
+wallet_name = "Missing a key"
+error = "INCORRECT_DATA"
+
+[[case]]
+name = "unsupported_bare_pk"
+description = "bare pk() top-level descriptor is not supported"
+descriptor_template = "pk(@0/**)"
+keys_info = [
+    "[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF",
+]
+wallet_name = "Unsupported"
+error = "NOT_SUPPORTED"
+
+[[case]]
+name = "not_sane_duplicate_key"
+description = "the same key appears twice in the keys vector"
+descriptor_template = "wsh(c:andor(pk(@0/<0;1>/*),pk_k(@1/**),and_v(v:pk(@2/<2;3>/*),pk_k(@3/**))))"
+keys_info = [
+    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+    "tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF",
+    "tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+    "tpubDDV6FDLcCieWUeN7R3vZK2Qs3KuQed3ScTY9EiwMXvyCkLjDbCb8RXaAgWDbkG4tW1BMKVF1zERHnyt78QKd4ZaAYGMJMpvHPwgSSU1AxZ3",
+]
+wallet_name = "Unsupported policy"
+error = "NOT_SUPPORTED"
+
+[[case]]
+name = "not_sane_overlapping_derivations"
+description = "same key with overlapping derivations"
+descriptor_template = "wsh(thresh(3,pk(@0/**),s:pk(@1/**),s:pk(@0/**),sln:older(12960)))"
+keys_info = [
+    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+    "tpubDDV6FDLcCieWUeN7R3vZK2Qs3KuQed3ScTY9EiwMXvyCkLjDbCb8RXaAgWDbkG4tW1BMKVF1zERHnyt78QKd4ZaAYGMJMpvHPwgSSU1AxZ3",
+]
+wallet_name = "Unsupported policy"
+error = "NOT_SUPPORTED"
+
+[[case]]
+name = "not_sane_timelock_mixing"
+description = "miniscript mixing time- and height-based absolute timelocks"
+descriptor_template = "wsh(thresh(2,c:pk_k(@0/**),ac:pk_k(@1/**),altv:after(1000000000),altv:after(100)))"
+keys_info = [
+    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+    "tpubDDV6FDLcCieWUeN7R3vZK2Qs3KuQed3ScTY9EiwMXvyCkLjDbCb8RXaAgWDbkG4tW1BMKVF1zERHnyt78QKd4ZaAYGMJMpvHPwgSSU1AxZ3",
+]
+wallet_name = "Timelock mixing is bad"
+error = "NOT_SUPPORTED"
+
+[[case]]
+name = "not_sane_no_signature_required"
+description = "miniscript that does not always require a signature"
+descriptor_template = "wsh(or_d(multi(1,@0/**),or_b(multi(3,@1/**,@2/**,@3/**),su:after(500000))))"
+keys_info = [
+    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+    "tpubDDV6FDLcCieWUeN7R3vZK2Qs3KuQed3ScTY9EiwMXvyCkLjDbCb8RXaAgWDbkG4tW1BMKVF1zERHnyt78QKd4ZaAYGMJMpvHPwgSSU1AxZ3",
+    "tpubDF6JT5K4izwALMpFv7fQrpWr5bGUMEoWphkzTVJH8jTfgirNEgGZnxsWJDCCxhg2UnW5RcD9Tx8aVAdoM734X5bnRGmJUujz26uQ5gAC1nE",
+    "tpubDF4kujkh5dAhC1pFgBToZybXdvJFXXGX4BWdDxWqP7EUpG8gxkfMQeDjGPDnTr9e4NrkFmDM1ocav3Jz6x79CRZbxGr9dzFokJLuvDDnyRh",
+]
+wallet_name = "No need for sig"
+error = "NOT_SUPPORTED"
+
+[[case]]
+name = "not_sane_malleable"
+description = "malleable miniscript policy"
+descriptor_template = "wsh(c:andor(ripemd160(6ad07d21fd5dfc646f0b30577045ce201616b9ba),pk_h(@0/**),and_v(v:hash256(8a35d9ca92a48eaade6f53a64985e9e2afeb74dcf8acb4c3721e0dc7e4294b25),pk_h(@1/**))))"
+keys_info = [
+    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+    "tpubDDV6FDLcCieWUeN7R3vZK2Qs3KuQed3ScTY9EiwMXvyCkLjDbCb8RXaAgWDbkG4tW1BMKVF1zERHnyt78QKd4ZaAYGMJMpvHPwgSSU1AxZ3",
+]
+wallet_name = "Malleable"
+error = "NOT_SUPPORTED"
+
+[[case]]
+name = "too_many_derivation_steps"
+description = "key with 9 derivation steps exceeds the maximum (8)"
+descriptor_template = "wpkh(@0/**)"
+keys_info = [
+    "[f5acc2fd/48'/1'/0'/2'/0'/1'/2'/3'/4']tpubDR1MRwnrfYuCbZ5dvozygap7EkR1pRXfwKhfCEpMTHtzrtN78MnFeipS2Vq9Nr3WHSurdqmrPfm5yQH5ikxJhYUTK12VxmqfTKR8hUF8mty",
+]
+wallet_name = "Too many steps"
+error = "INCORRECT_DATA"
+
+[[case]]
+name = "too_many_keys"
+description = "16 key expressions exceed the maximum (15) supported in a wallet policy"
+descriptor_template = "wsh(multi(1,@0/**,@1/**,@2/**,@3/**,@4/**,@5/**,@6/**,@7/**,@8/**,@9/**,@10/**,@11/**,@12/**,@13/**,@14/**,@15/**))"
+keys_info = [
+    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+    "tpubDD814oESVM3uG2yZZDnJDex6gLeeahu2cmK2AL26ozTtDouQCY4NA8xcTW5oiJLp1cydFtDPdWxWDpLPGyLo6sGbemykJm4ocjjvt5cwvtv",
+    "tpubDCz2AbmcM5cVir5UiGjdPgtY6Tugwg44VZYJjpPxyZAg9vMsztGVjcgW9wkQF3oDF4mK2vRxzeXY7d31KYStsRQtuhPNpLFJgz3A3Np9Vc8",
+    "tpubDCbN8YbwHgkEVHc3kYfJirFiHaQaR9brzgF6KNhnceLe58hWiHMDXrovq3SBbHBcHHhNiXNSY7wKWRUGb3pYDTeEnVJBqthwG3FhgeuUQjb",
+    "tpubDD3GzZF6koScghQdMUZ1VT6UnNyvvhVGwwEaReiHSPrKxFguBhp6K2kpbKUwudodaQy44EDbUz4rLgGGN5XJmqCTrydxwY9sRmErUGmK8XA",
+    "tpubDDi6fvvXrjwNvm9tRrAowv5MmxajeptXACMAoVTGSS7dCfabntWJk6eaxFYTy3SLnphoLDs8wzkuQF54x5fiT63dYQ8FBQZWxVSVgNqZUCb",
+    "tpubDDtawMw95R6dzwnW6ptNwAHJVHQRS8vYCyXBVrycd6hnqDfPjBpyMxBbgFgZCdp5oX5L34Z42tvetavdvzcRubV7Yc6mh639uDjRvHDFTrB",
+    "tpubDCDtoPWjoKyu8BurUA6erB4hDBtN18xybX2mFSY1AWXy5qem2j79MbzGiJiNUZsqzLXUuoxjDhwCvACr8NSTukFLWPpgLZSS7KGawZSkTKQ",
+    "tpubDCXuqAmWrb4Zv2wRsjW3iaCN4EddaxFwMDnrfBaonLKDKvnkAzR5yar6CpAU6XiQpXJtirSfjJ1UjTs4ZnUXFpCM3Jr6Y8WgbPGhRgo7vXW",
+    "tpubDDpVtgEAwc9QGnxi6froduQcPHUFQKfz8XDRvjnwqXPTYQYzjTmPkepYQkD5vymqQanH2sMZsu6GYvfpzrPgvBiUUmpuYuWnotukE1h1zBb",
+    "tpubDDCK19rtBJsMt8Jb5eoJZKwF8C46HDY6qGrfuDSmtzb3nXA3X7h8DgQrTRbdaRMPziwo9CfS9xK8s8mDqAztqC2MTp1ZuK51Jr2DKweqkKY",
+    "tpubDCFwnN6jcEGzVsxTe7yX72zModdxsdAXi8C6t3xEqGKwkZd2ke2cExXgTNSbTM25FdzUxZXj6EhzLGZdPYtDk1hQbUgkak7HLJppn3erid2",
+    "tpubDDCaqm7sT9mSE1tQFcDnxrGvS7wJkVZ2UyL2daVVUVuWSSkco3u8pKyJSH7uRJKu48gudpXzWa8XqGzSPmbZN2SwPpkKE3GbXvpQB9euuNS",
+    "tpubDDXidKmnHQnn7XNBfV6ngDqyporatWXdUGSayXBTm1WQwQGrtcPb38zaZGo3y3K6KnD37dAnU66JWcLEY53F8zRKeBT7J5Y27ER5TTcDhr6",
+    "tpubDCyakepujvAQzi2S6eVYrC6ky5mBfHe3xE4fxj3FaT4Nt7TvmGW7w22kJ5EF4XR33oLc2PAGveNymx8tubaSZ4wA6ja7cnE3t4maND5ehep",
+    "tpubDDExGXv7gGXC7aXxQoajPixpn6o5BPLPYL3DFouZd3GmNwSi8cKBLn51y6Deh2jHcCDB88e4R51oqn5iK9pvsyUKV6BPieMCbCn8Qzd6GPs",
+]
+wallet_name = "Too many keys"
+error = "NOT_SUPPORTED"
+
+[[case]]
+name = "no_internal_key"
+description = "policy with only a foreign key (fingerprint never matches ours)"
+descriptor_template = "wpkh(@0/**)"
+keys_info = [
+    "[76223a6e/48'/1'/0'/2']tpubDD814oESVM3uG2yZZDnJDex6gLeeahu2cmK2AL26ozTtDouQCY4NA8xcTW5oiJLp1cydFtDPdWxWDpLPGyLo6sGbemykJm4ocjjvt5cwvtv",
+]
+wallet_name = "No internal key"
+error = "INCORRECT_DATA"
+
+[[case]]
+name = "no_internal_key_fp_collision"
+description = "key has our fingerprint but a foreign xpub; the re-derivation mismatch must keep it external (no internal key)"
+descriptor_template = "wpkh(@0/**)"
+keys_info = [
+    "[f5acc2fd/44'/1'/3']tpubDD814oESVM3uG2yZZDnJDex6gLeeahu2cmK2AL26ozTtDouQCY4NA8xcTW5oiJLp1cydFtDPdWxWDpLPGyLo6sGbemykJm4ocjjvt5cwvtv",
+]
+wallet_name = "Fingerprint collision"
+error = "INCORRECT_DATA"
+

--- a/test_vectors/sign_message.toml
+++ b/test_vectors/sign_message.toml
@@ -10,36 +10,42 @@ name = "times_headline"
 message = "The Times 03/Jan/2009 Chancellor on brink of second bailout for banks."
 path = "m/44'/1'/0'/0/0"
 expected_signature = "IOR4YRVlmJGMx+H7PgQvHzWAF0HAgrUggQeRdnoWKpypfaAberpvF+XbOCM5Cd/ljogNyU3w2OIL8eYCyZ6Ru2k="
+displayed_as = "message"
 
 [[case]]
 name = "times_headline_with_eol"
 message = "\nThe Times 03/Jan/2009 Chancellor\non brink of second bailout for banks."
 path = "m/44'/1'/0'/0/0"
 expected_signature = "ILMgIpFxqZwrB5bgR/seis2N48jS7pmHViKcRYisIPBdDjhAzGDGP3HiLPcrYMlEOXJvdJ9/Mud/+fslM2KtKaM="
+displayed_as = "message"
 
 [[case]]
 name = "hello_world"
 message = "Hello world!"
 path = "m/84'/1'/0'/0/0"
 expected_signature = "IEOK4+JMK7FToR7XMzFCoAYh1nud1IKm9Wq3vXLSVk/lBay8rHCRp9bP6riyR5NDqXYyYf7cXgMQTHNz3SemwZI="
+displayed_as = "message"
 
 [[case]]
 name = "long_multileaf"
 message = "The root problem with conventional currency is all the trust that's required to make it work. The central bank must be trusted not to debase the currency, but the history of fiat currencies is full of breaches of that trust. Banks must be trusted to hold our money and transfer it electronically, but they lend it out in waves of credit bubbles with barely a fraction in reserve. We have to trust them with our privacy, trust them not to let identity thieves drain our accounts. Their massive overhead costs make micropayments impossible."
 path = "m/84'/1'/0'/0/8"
 expected_signature = "H4frM6TYm5ty1MAf9o/Zz9Qiy3VEldAYFY91SJ/5nYMAZY1UUB97fiRjKW8mJit2+V4OCa1YCqjDqyFnD9Fw75k="
+displayed_as = "message"
 
 [[case]]
 name = "non_ascii_carriage_return"
 message = "Hello\rworld!"
 path = "m/84'/1'/0'/0/8"
 expected_signature = "ILXQPJapQ/OEy9f/ggRouI6HuAleQveIOBphNUCLlWNVQAml2Yx+885tsU0DKIxggsVq53o/fQRlosTPTQE/keE="
+displayed_as = "hash"
 
 [[case]]
 name = "too_long_to_display"
 message = "The root problem with conventional currency is all the trust that's required to make it work. The central bank must be trusted not to debase the currency, but the history of fiat currencies is full of breaches of that trust. Banks must be trusted to hold our money and transfer it electronically, but they lend it out in waves of credit bubbles with barely a fraction in reserve. We have to trust them with our privacy, trust them not to let identity thieves drain our accounts. Their massive overhead costs make micropayments impossible. The root problem with conventional currency is all the trust that's required to make it work. The central bank must be trusted not to debase the currency, but the history of fiat currencies is full of breaches of that trust. Banks must be trusted to hold our money and transfer it electronically, but they lend it out in waves of credit bubbles with barely a fraction in reserve. We have to trust them with our privacy, trust them not to let identity thieves drain our accounts. Their massive overhead costs make micropayments impossible. The root problem with conventional currency is all the trust that's required to make it work. The central bank must be trusted not to debase the currency, but the history of fiat currencies is full of breaches of that trust. Banks must be trusted to hold our money and transfer it electronically, but they lend it out in waves of credit bubbles with barely a fraction in reserve. We have to trust them with our privacy, trust them not to let identity thieves drain our accounts. Their massive overhead costs make micropayments impossible."
 path = "m/84'/1'/0'/0/8"
 expected_signature = "IDAl9RThAyunmYuol9DaDs/CScUpiol3FDSjIjyK9y0tc/x1HWrbT/ufdkPFY1Bmi+L9hc3ip1me2RmufprVuNk="
+displayed_as = "hash"
 
 # Path with 11 derivation steps exceeds the maximum (10): WRONG_DATA_LENGTH.
 [[case]]

--- a/test_vectors/sign_message.toml
+++ b/test_vectors/sign_message.toml
@@ -1,0 +1,49 @@
+# Test vectors for sign_message.
+#
+# Source: tests/test_sign_message.py
+#
+# `message` is the UTF-8 text to sign; `expected_signature` is the base64 result.
+# Pure UI reject flows (DENY) are not captured here.
+
+[[case]]
+name = "times_headline"
+message = "The Times 03/Jan/2009 Chancellor on brink of second bailout for banks."
+path = "m/44'/1'/0'/0/0"
+expected_signature = "IOR4YRVlmJGMx+H7PgQvHzWAF0HAgrUggQeRdnoWKpypfaAberpvF+XbOCM5Cd/ljogNyU3w2OIL8eYCyZ6Ru2k="
+
+[[case]]
+name = "times_headline_with_eol"
+message = "\nThe Times 03/Jan/2009 Chancellor\non brink of second bailout for banks."
+path = "m/44'/1'/0'/0/0"
+expected_signature = "ILMgIpFxqZwrB5bgR/seis2N48jS7pmHViKcRYisIPBdDjhAzGDGP3HiLPcrYMlEOXJvdJ9/Mud/+fslM2KtKaM="
+
+[[case]]
+name = "hello_world"
+message = "Hello world!"
+path = "m/84'/1'/0'/0/0"
+expected_signature = "IEOK4+JMK7FToR7XMzFCoAYh1nud1IKm9Wq3vXLSVk/lBay8rHCRp9bP6riyR5NDqXYyYf7cXgMQTHNz3SemwZI="
+
+[[case]]
+name = "long_multileaf"
+message = "The root problem with conventional currency is all the trust that's required to make it work. The central bank must be trusted not to debase the currency, but the history of fiat currencies is full of breaches of that trust. Banks must be trusted to hold our money and transfer it electronically, but they lend it out in waves of credit bubbles with barely a fraction in reserve. We have to trust them with our privacy, trust them not to let identity thieves drain our accounts. Their massive overhead costs make micropayments impossible."
+path = "m/84'/1'/0'/0/8"
+expected_signature = "H4frM6TYm5ty1MAf9o/Zz9Qiy3VEldAYFY91SJ/5nYMAZY1UUB97fiRjKW8mJit2+V4OCa1YCqjDqyFnD9Fw75k="
+
+[[case]]
+name = "non_ascii_carriage_return"
+message = "Hello\rworld!"
+path = "m/84'/1'/0'/0/8"
+expected_signature = "ILXQPJapQ/OEy9f/ggRouI6HuAleQveIOBphNUCLlWNVQAml2Yx+885tsU0DKIxggsVq53o/fQRlosTPTQE/keE="
+
+[[case]]
+name = "too_long_to_display"
+message = "The root problem with conventional currency is all the trust that's required to make it work. The central bank must be trusted not to debase the currency, but the history of fiat currencies is full of breaches of that trust. Banks must be trusted to hold our money and transfer it electronically, but they lend it out in waves of credit bubbles with barely a fraction in reserve. We have to trust them with our privacy, trust them not to let identity thieves drain our accounts. Their massive overhead costs make micropayments impossible. The root problem with conventional currency is all the trust that's required to make it work. The central bank must be trusted not to debase the currency, but the history of fiat currencies is full of breaches of that trust. Banks must be trusted to hold our money and transfer it electronically, but they lend it out in waves of credit bubbles with barely a fraction in reserve. We have to trust them with our privacy, trust them not to let identity thieves drain our accounts. Their massive overhead costs make micropayments impossible. The root problem with conventional currency is all the trust that's required to make it work. The central bank must be trusted not to debase the currency, but the history of fiat currencies is full of breaches of that trust. Banks must be trusted to hold our money and transfer it electronically, but they lend it out in waves of credit bubbles with barely a fraction in reserve. We have to trust them with our privacy, trust them not to let identity thieves drain our accounts. Their massive overhead costs make micropayments impossible."
+path = "m/84'/1'/0'/0/8"
+expected_signature = "IDAl9RThAyunmYuol9DaDs/CScUpiol3FDSjIjyK9y0tc/x1HWrbT/ufdkPFY1Bmi+L9hc3ip1me2RmufprVuNk="
+
+# Path with 11 derivation steps exceeds the maximum (10): WRONG_DATA_LENGTH.
+[[case]]
+name = "too_long_bip32_path"
+message = "Too long derivation path test"
+path = "m/44'/1'/0'/0'/1'/2'/3'/4'/5/6/7"
+error = "WRONG_DATA_LENGTH"

--- a/test_vectors/sign_psbt.toml
+++ b/test_vectors/sign_psbt.toml
@@ -1,0 +1,293 @@
+# Test vectors for sign_psbt.
+#
+# Schema and conventions are documented in test_vectors/README.md.
+# Sources: tests/test_sign_psbt.py and tests/test_sign_psbt_with_sighash_types.py.
+#
+# Each case references a PSBT fixture (psbt_file, relative to tests/) plus a wallet
+# policy block, and lists the expected signatures per input. For each signature:
+#   - `sighash_type` is the SIGHASH flag the input is signed with (always present);
+#   - deterministic ECDSA signatures carry exact `signature` bytes;
+#   - taproot Schnorr signatures (non-deterministic) instead carry the `sighash`
+#     digest the signature must verify against (BIP-340), since the produced bytes
+#     are not byte-stable.
+#
+# Randomized PSBTs (txmaker), PSBT-mutation tests, and pure UI flows stay as
+# bespoke code in each framework.
+
+[[case]]
+name = "singlesig_pkh_1to1"
+description = "legacy P2PKH, 1 input 1 output"
+psbt_file = "psbt/singlesig/pkh-1to1.psbt"
+descriptor_template = "pkh(@0/**)"
+keys_info = [
+    "[f5acc2fd/44'/1'/0']tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT",
+]
+
+[[case.expected_signatures]]
+input_index = 0
+pubkey = "02ee8608207e21028426f69e76447d7e3d5e077049f5e683c3136c2314762a4718"
+sighash_type = 1
+signature = "3045022100e55b3ca788721aae8def2eadff710e524ffe8c9dec1764fdaa89584f9726e196022012a30fbcf9e1a24df31a1010356b794ab8de438b4250684757ed5772402540f401"
+
+[[case]]
+name = "singlesig_sh_wpkh_1to2"
+description = "wrapped segwit P2SH-P2WPKH, 1 input 2 outputs"
+psbt_file = "psbt/singlesig/sh-wpkh-1to2.psbt"
+descriptor_template = "sh(wpkh(@0/**))"
+keys_info = [
+    "[f5acc2fd/49'/1'/0']tpubDC871vGLAiKPcwAw22EjhKVLk5L98UGXBEcGR8gpcigLQVDDfgcYW24QBEyTHTSFEjgJgbaHU8CdRi9vmG4cPm1kPLmZhJEP17FMBdNheh3",
+]
+
+[[case.expected_signatures]]
+input_index = 0
+pubkey = "024ba3b77d933de9fa3f9583348c40f3caaf2effad5b6e244ece8abbfcc7244f67"
+sighash_type = 1
+signature = "30440220720722b08489c2a50d10edea8e21880086c8e8f22889a16815e306daeea4665b02203fcf453fa490b76cf4f929714065fc90a519b7b97ab18914f9451b5a4b45241201"
+
+[[case]]
+name = "singlesig_wpkh_1to2"
+description = "native segwit P2WPKH, 1 input 2 outputs"
+psbt_file = "psbt/singlesig/wpkh-1to2.psbt"
+descriptor_template = "wpkh(@0/**)"
+keys_info = [
+    "[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P",
+]
+
+[[case.expected_signatures]]
+input_index = 0
+pubkey = "03ee2c3d98eb1f93c0a1aa8e5a4009b70eb7b44ead15f1666f136b012ad58d3068"
+sighash_type = 1
+signature = "3045022100ab44f34dd7e87c9054591297a101e8500a0641d1d591878d0d23cf8096fa79e802205d12d1062d925e27b57bdcf994ecf332ad0a8e67b8fe407bab2101255da632aa01"
+
+[[case]]
+name = "singlesig_wpkh_2to2"
+description = "native segwit P2WPKH, 2 inputs 2 outputs"
+psbt_file = "psbt/singlesig/wpkh-2to2.psbt"
+descriptor_template = "wpkh(@0/**)"
+keys_info = [
+    "[f5acc2fd/84'/1'/0']tpubDCtKfsNyRhULjZ9XMS4VKKtVcPdVDi8MKUbcSD9MJDyjRu1A2ND5MiipozyyspBT9bg8upEp7a8EAgFxNxXn1d7QkdbL52Ty5jiSLcxPt1P",
+]
+
+[[case.expected_signatures]]
+input_index = 0
+pubkey = "03455ee7cedc97b0ba435b80066fc92c963a34c600317981d135330c4ee43ac7a3"
+sighash_type = 1
+signature = "304402206b3e877655f08c6e7b1b74d6d893a82cdf799f68a5ae7cecae63a71b0339e5ce022019b94aa3fb6635956e109f3d89c996b1bfbbaf3c619134b5a302badfaf52180e01"
+
+[[case.expected_signatures]]
+input_index = 1
+pubkey = "0271b5b779ad870838587797bcf6f0c7aec5abe76a709d724f48d2e26cf874f0a0"
+sighash_type = 1
+signature = "3045022100e2e98e4f8c70274f10145c89a5d86e216d0376bdf9f42f829e4315ea67d79d210220743589fd4f55e540540a976a5af58acd610fa5e188a5096dfe7d36baf3afb94001"
+
+[[case]]
+name = "multisig_wsh_2of2"
+description = "native segwit 2-of-2 sortedmulti"
+psbt_file = "psbt/multisig/wsh-2of2.psbt"
+descriptor_template = "wsh(sortedmulti(2,@0/**,@1/**))"
+keys_info = [
+    "[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF",
+    "[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK",
+]
+wallet_name = "Cold storage"
+wallet_hmac = "d7c7a60b4ab4a14c1bf8901ba627d72140b2fb907f2b4e35d2e693bce9fbb371"
+
+[[case.expected_signatures]]
+input_index = 0
+pubkey = "036b16e8c1f979fa4cc0f05b6a300affff941459b6f20de77de55b0160ef8e4cac"
+sighash_type = 1
+signature = "304402206ab297c83ab66e573723892061d827c5ac0150e2044fed7ed34742fedbcfb26e0220319cdf4eaddff63fc308cdf53e225ea034024ef96de03fd0939b6deeea1e8bd301"
+
+[[case]]
+name = "singlesig_tr_1to2_sighash_all"
+description = "taproot keypath, SIGHASH_ALL (verify against digest)"
+psbt_file = "psbt/singlesig/tr-1to2-sighash-all.psbt"
+descriptor_template = "tr(@0/**)"
+keys_info = [
+    "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U",
+]
+
+[[case.expected_signatures]]
+input_index = 0
+pubkey = "d8f4f1d18996db61bb1caf5423de25d8a1eee9c950d37e6ffa023012d5e62e0d"
+sighash_type = 1
+sighash = "7A999E5AD6F53EA6448E7026061D3B4523F957999C430A5A492DFACE74AE31B6"
+
+[[case]]
+name = "singlesig_tr_1to2_sighash_default"
+description = "taproot keypath, SIGHASH_DEFAULT (64-byte sig, verify against digest)"
+psbt_file = "psbt/singlesig/tr-1to2-sighash-default.psbt"
+descriptor_template = "tr(@0/**)"
+keys_info = [
+    "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U",
+]
+
+[[case.expected_signatures]]
+input_index = 0
+pubkey = "89904a6348d7ff9a44d49db8b6a807c622e868364c547da426f30b5a6213186a"
+sighash_type = 0
+sighash = "75C96FB06A12DB4CD011D8C95A5995DB758A4F2837A22F30F0F579619A4466F3"
+
+[[case]]
+name = "singlesig_tr_1to2_sighash_omitted"
+description = "taproot keypath, SIGHASH_DEFAULT (64-byte sig, verify against digest)"
+psbt_file = "psbt/singlesig/tr-1to2-sighash-omitted.psbt"
+descriptor_template = "tr(@0/**)"
+keys_info = [
+    "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U",
+]
+
+[[case.expected_signatures]]
+input_index = 0
+pubkey = "89904a6348d7ff9a44d49db8b6a807c622e868364c547da426f30b5a6213186a"
+sighash_type = 0
+sighash = "75C96FB06A12DB4CD011D8C95A5995DB758A4F2837A22F30F0F579619A4466F3"
+
+[[case]]
+name = "sighash_all"
+description = "taproot keypath, sighash flag 0x01, 2 inputs (verify against digests)"
+psbt_file = "psbt/sighash/sighash-all-sign.psbt"
+descriptor_template = "tr(@0/**)"
+keys_info = [
+    "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U",
+]
+
+[[case.expected_signatures]]
+input_index = 0
+pubkey = "0b8e7486bc306a0aefb7a7c00af0405542db1acd73eecca82771ccf5fe5eb60f"
+sighash_type = 1
+sighash = "2221AA462110C77A8E2DD34C3681BAA9BFFF6553B4C609EC7E3D8FF9B1D18D69"
+
+[[case.expected_signatures]]
+input_index = 1
+pubkey = "41461489a43cb67e2c64f39427278edd30c03d6d72a4b89986147c428f0cc5f1"
+sighash_type = 1
+sighash = "D47D3FA22B4F6C50521C49E1A42E8CB10689540A227491A8FC5AD0A6E413063E"
+
+[[case]]
+name = "sighash_none"
+description = "taproot keypath, sighash flag 0x02, 2 inputs (verify against digests)"
+psbt_file = "psbt/sighash/sighash-none-sign.psbt"
+descriptor_template = "tr(@0/**)"
+keys_info = [
+    "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U",
+]
+
+[[case.expected_signatures]]
+input_index = 0
+pubkey = "0b8e7486bc306a0aefb7a7c00af0405542db1acd73eecca82771ccf5fe5eb60f"
+sighash_type = 2
+sighash = "965976D58A387369D970F0B6560B144E1B721D41E04675592C41AC35D30D2A56"
+
+[[case.expected_signatures]]
+input_index = 1
+pubkey = "41461489a43cb67e2c64f39427278edd30c03d6d72a4b89986147c428f0cc5f1"
+sighash_type = 2
+sighash = "67E85534A12E4054F4AFAA434D7A7C38123DA6909DF7E45DDB9945F7B8D832D0"
+
+[[case]]
+name = "sighash_single"
+description = "taproot keypath, sighash flag 0x03, 2 inputs (verify against digests)"
+psbt_file = "psbt/sighash/sighash-single-sign.psbt"
+descriptor_template = "tr(@0/**)"
+keys_info = [
+    "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U",
+]
+
+[[case.expected_signatures]]
+input_index = 0
+pubkey = "0b8e7486bc306a0aefb7a7c00af0405542db1acd73eecca82771ccf5fe5eb60f"
+sighash_type = 3
+sighash = "F9B834D7FE272F9EACE2FC5F7A97468B024438EF5D55338FC243D5273534A6B5"
+
+[[case.expected_signatures]]
+input_index = 1
+pubkey = "41461489a43cb67e2c64f39427278edd30c03d6d72a4b89986147c428f0cc5f1"
+sighash_type = 3
+sighash = "9A4DDC13C6D0EE10A41D33C6595C63F51AF4C9314387685304F515F790260F78"
+
+[[case]]
+name = "sighash_all_anyonecanpay"
+description = "taproot keypath, sighash flag 0x81, 2 inputs (verify against digests)"
+psbt_file = "psbt/sighash/sighash-all-anyone-can-pay-sign.psbt"
+descriptor_template = "tr(@0/**)"
+keys_info = [
+    "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U",
+]
+
+[[case.expected_signatures]]
+input_index = 0
+pubkey = "0b8e7486bc306a0aefb7a7c00af0405542db1acd73eecca82771ccf5fe5eb60f"
+sighash_type = 129
+sighash = "09A6559AF84C48C8D5A7984C5A72E53ED88D160AABAE99C18F00E78A55E7EDC7"
+
+[[case.expected_signatures]]
+input_index = 1
+pubkey = "41461489a43cb67e2c64f39427278edd30c03d6d72a4b89986147c428f0cc5f1"
+sighash_type = 129
+sighash = "9B25C319E12F4755D8A43F3295B8C61B861FB23D7EBF7F9A25E6E8CE3242F939"
+
+[[case]]
+name = "sighash_none_anyonecanpay"
+description = "taproot keypath, sighash flag 0x82, 2 inputs (verify against digests)"
+psbt_file = "psbt/sighash/sighash-none-anyone-can-pay-sign.psbt"
+descriptor_template = "tr(@0/**)"
+keys_info = [
+    "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U",
+]
+
+[[case.expected_signatures]]
+input_index = 0
+pubkey = "0b8e7486bc306a0aefb7a7c00af0405542db1acd73eecca82771ccf5fe5eb60f"
+sighash_type = 130
+sighash = "8FCEFFAE04D320E05DE04034069FE6AF8C7CBCC93CDE3F187AB0DEC202692735"
+
+[[case.expected_signatures]]
+input_index = 1
+pubkey = "41461489a43cb67e2c64f39427278edd30c03d6d72a4b89986147c428f0cc5f1"
+sighash_type = 130
+sighash = "A06D37C1C8EEE7EA145F9D8A98CBE79F6BB1691B37F8F26F49F8318F9443B766"
+
+[[case]]
+name = "sighash_single_anyonecanpay"
+description = "taproot keypath, sighash flag 0x83, 2 inputs (verify against digests)"
+psbt_file = "psbt/sighash/sighash-single-anyone-can-pay-sign.psbt"
+descriptor_template = "tr(@0/**)"
+keys_info = [
+    "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U",
+]
+
+[[case.expected_signatures]]
+input_index = 0
+pubkey = "0b8e7486bc306a0aefb7a7c00af0405542db1acd73eecca82771ccf5fe5eb60f"
+sighash_type = 131
+sighash = "971886B247797E0A616489B449B5E78AE8EC63E54B55727AF626B964DD8F329D"
+
+[[case.expected_signatures]]
+input_index = 1
+pubkey = "41461489a43cb67e2c64f39427278edd30c03d6d72a4b89986147c428f0cc5f1"
+sighash_type = 131
+sighash = "6B130F2BE5467A8BC36227B8C2A082B46CA24F91A6A6A54AA5EFA4901BE5ADBB"
+
+# ---- Deterministic rejections ----
+
+[[case]]
+name = "sighash_single_unallowed_3ins_2outs"
+description = "SIGHASH_SINGLE with input index >= number of outputs is rejected"
+psbt_file = "psbt/sighash/sighash-single-3-ins-2-outs.psbt"
+descriptor_template = "tr(@0/**)"
+keys_info = [
+    "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U",
+]
+error = "NOT_SUPPORTED"
+
+[[case]]
+name = "sighash_unsupported_type"
+description = "unsupported sighash type is rejected"
+psbt_file = "psbt/sighash/sighash-unsupported.psbt"
+descriptor_template = "tr(@0/**)"
+keys_info = [
+    "[f5acc2fd/86'/1'/0']tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U",
+]
+error = "NOT_SUPPORTED"
+

--- a/unit-tests/CMakeLists.txt
+++ b/unit-tests/CMakeLists.txt
@@ -343,4 +343,23 @@ if(SPECULOS AND SPECULOS_SRC)
     cmocka mock_dispatcher app_crypto buffer buffer_ext tomlc17
   )
   add_test(test_get_wallet_address test_get_wallet_address)
+
+  # test_get_extended_pubkey exercises handler_get_extended_pubkey (compiled
+  # directly into the test) against the vectors in
+  # ../test_vectors/get_extended_pubkey.toml. It drives the handler through the
+  # mock dispatcher (which backs the response buffer) and provides a capturing
+  # stub for the UI symbol the handler references (ui_display_pubkey).
+  add_executable(test_get_extended_pubkey
+    test_get_extended_pubkey.c
+    ../src/handler/get_extended_pubkey.c
+  )
+  app_apply_real_sdk_config(test_get_extended_pubkey)
+  target_include_directories(test_get_extended_pubkey BEFORE PRIVATE ../src/ui)
+  target_compile_definitions(test_get_extended_pubkey PRIVATE
+    TEST_VECTORS_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/../test_vectors/get_extended_pubkey.toml\"
+  )
+  target_link_libraries(test_get_extended_pubkey PRIVATE
+    cmocka mock_dispatcher app_crypto buffer buffer_ext tomlc17
+  )
+  add_test(test_get_extended_pubkey test_get_extended_pubkey)
 endif()

--- a/unit-tests/CMakeLists.txt
+++ b/unit-tests/CMakeLists.txt
@@ -362,4 +362,24 @@ if(SPECULOS AND SPECULOS_SRC)
     cmocka mock_dispatcher app_crypto buffer buffer_ext tomlc17
   )
   add_test(test_get_extended_pubkey test_get_extended_pubkey)
+
+  # test_register_wallet exercises the UI-free core of handler_register_wallet
+  # (the handler source is compiled directly into the test) against the vectors
+  # in ../test_vectors/register_wallet.toml. It drives the handler through the
+  # mock dispatcher (which serves the keys Merkle tree and the descriptor
+  # preimage) and provides a stub for the UI symbol the handler references
+  # (ui_display_register_wallet_policy).
+  add_executable(test_register_wallet
+    test_register_wallet.c
+    ../src/handler/register_wallet.c
+  )
+  app_apply_real_sdk_config(test_register_wallet)
+  target_include_directories(test_register_wallet BEFORE PRIVATE ../src/ui)
+  target_compile_definitions(test_register_wallet PRIVATE
+    TEST_VECTORS_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/../test_vectors/register_wallet.toml\"
+  )
+  target_link_libraries(test_register_wallet PRIVATE
+    cmocka mock_dispatcher app_crypto buffer buffer_ext tomlc17
+  )
+  add_test(test_register_wallet test_register_wallet)
 endif()

--- a/unit-tests/CMakeLists.txt
+++ b/unit-tests/CMakeLists.txt
@@ -382,4 +382,22 @@ if(SPECULOS AND SPECULOS_SRC)
     cmocka mock_dispatcher app_crypto buffer buffer_ext tomlc17
   )
   add_test(test_register_wallet test_register_wallet)
+
+  # test_sign_message exercises handler_sign_message (compiled directly into the
+  # test) against the vectors in ../test_vectors/sign_message.toml. It drives the
+  # handler through the mock dispatcher (which streams back the message chunks)
+  # and provides capturing stubs for the UI symbols the handler references.
+  add_executable(test_sign_message
+    test_sign_message.c
+    ../src/handler/sign_message.c
+  )
+  app_apply_real_sdk_config(test_sign_message)
+  target_include_directories(test_sign_message BEFORE PRIVATE ../src/ui)
+  target_compile_definitions(test_sign_message PRIVATE
+    TEST_VECTORS_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/../test_vectors/sign_message.toml\"
+  )
+  target_link_libraries(test_sign_message PRIVATE
+    cmocka mock_dispatcher app_crypto buffer buffer_ext tomlc17
+  )
+  add_test(test_sign_message test_sign_message)
 endif()

--- a/unit-tests/CMakeLists.txt
+++ b/unit-tests/CMakeLists.txt
@@ -332,12 +332,12 @@ if(SPECULOS AND SPECULOS_SRC)
   add_test(test_wallet test_wallet)
 
   # test_get_wallet_address exercises get_wallet_script + get_script_address
-  # end-to-end against a mock dispatcher; vectors come from a separate
-  # TOML file (see test_get_wallet_address_vectors.toml).
+  # end-to-end against a mock dispatcher; vectors come from the test assets
+  # in the repository root (see ../test_vectors/get_wallet_address.toml).
   add_executable(test_get_wallet_address test_get_wallet_address.c)
   app_apply_real_sdk_config(test_get_wallet_address)
   target_compile_definitions(test_get_wallet_address PRIVATE
-    TEST_VECTORS_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/test_get_wallet_address_vectors.toml\"
+    TEST_VECTORS_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/../test_vectors/get_wallet_address.toml\"
   )
   target_link_libraries(test_get_wallet_address PRIVATE
     cmocka mock_dispatcher app_crypto buffer buffer_ext tomlc17

--- a/unit-tests/libs/toml_helpers.h
+++ b/unit-tests/libs/toml_helpers.h
@@ -1,0 +1,81 @@
+#pragma once
+
+/**
+ * Header-only helpers for the data-driven unit tests that load their vectors
+ * from a TOML file (via the vendored tomlc17 parser).
+ *
+ * These run from each test's main() before cmocka_run_group_tests_name(), so
+ * there is no active test (and no setjmp buffer) for cmocka's fail() / assert_*
+ * macros to unwind to. On malformed input they abort() the process instead,
+ * which gives a deterministic, non-zero exit.
+ *
+ * All helpers are static inline so the header can be included from multiple
+ * translation units without violating the one-definition rule; unused ones are
+ * dropped without warning.
+ */
+
+#include <limits.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tomlc17.h"
+
+/* Copy a required string field from a TOML table into a fixed-size buffer.
+ * Aborts the process if the field is missing or doesn't fit. */
+static inline void copy_required_string(toml_datum_t table,
+                                        const char *key,
+                                        char *dst,
+                                        size_t dst_size) {
+    toml_datum_t d = toml_get(table, key);
+    if (d.type != TOML_STRING) {
+        fprintf(stderr, "missing or non-string field: %s\n", key);
+        abort();
+    }
+    if ((size_t) d.u.str.len >= dst_size) {
+        fprintf(stderr, "field %s too long (%d >= %zu)\n", key, d.u.str.len, dst_size);
+        abort();
+    }
+    memcpy(dst, d.u.str.ptr, (size_t) d.u.str.len);
+    dst[d.u.str.len] = '\0';
+}
+
+/* Copy an optional string field; returns true if it was present. Aborts only
+ * if the field is present but doesn't fit. */
+static inline bool copy_optional_string(toml_datum_t table,
+                                        const char *key,
+                                        char *dst,
+                                        size_t dst_size) {
+    toml_datum_t d = toml_get(table, key);
+    if (d.type != TOML_STRING) {
+        return false;
+    }
+    if ((size_t) d.u.str.len >= dst_size) {
+        fprintf(stderr, "field %s too long (%d >= %zu)\n", key, d.u.str.len, dst_size);
+        abort();
+    }
+    memcpy(dst, d.u.str.ptr, (size_t) d.u.str.len);
+    dst[d.u.str.len] = '\0';
+    return true;
+}
+
+/* Copy a required non-negative integer field. Aborts if missing, non-integer,
+ * negative, or larger than UINT_MAX. */
+static inline unsigned int copy_required_uint(toml_datum_t table, const char *key) {
+    toml_datum_t d = toml_get(table, key);
+    if (d.type != TOML_INT64) {
+        fprintf(stderr, "missing or non-integer field: %s\n", key);
+        abort();
+    }
+    if (d.u.int64 < 0) {
+        fprintf(stderr, "negative integer in field: %s\n", key);
+        abort();
+    }
+    if (d.u.int64 > UINT_MAX) {
+        fprintf(stderr, "integer in field %s too large\n", key);
+        abort();
+    }
+    return (unsigned int) d.u.int64;
+}

--- a/unit-tests/libs/toml_helpers.h
+++ b/unit-tests/libs/toml_helpers.h
@@ -49,8 +49,12 @@ static inline bool copy_optional_string(toml_datum_t table,
                                         char *dst,
                                         size_t dst_size) {
     toml_datum_t d = toml_get(table, key);
-    if (d.type != TOML_STRING) {
+    if (d.type == TOML_UNKNOWN) {
         return false;
+    }
+    if (d.type != TOML_STRING) {
+        fprintf(stderr, "non-string field: %s\n", key);
+        abort();
     }
     if ((size_t) d.u.str.len >= dst_size) {
         fprintf(stderr, "field %s too long (%d >= %zu)\n", key, d.u.str.len, dst_size);

--- a/unit-tests/test_get_extended_pubkey.c
+++ b/unit-tests/test_get_extended_pubkey.c
@@ -1,0 +1,349 @@
+/**
+ * Unit tests for handler_get_extended_pubkey.
+ *
+ * Test cases are loaded from TEST_VECTORS_PATH (a TOML file) at runtime; see the
+ * file's header comment for the schema. The handler source is compiled directly
+ * into the test and driven through the mock dispatcher (which backs the response
+ * buffer); the UI confirmation is replaced with a capturing stub. For each
+ * vector we serialize the get_extended_pubkey command data exactly as the Python
+ * command_builder does — display(1) || path_len(1) || path(4*len, big-endian) —
+ * and run the handler twice:
+ *   - display = 0: a `standard` path is exported (SW_OK) without confirmation; a
+ *                  non-standard one is rejected with NOT_SUPPORTED.
+ *   - display = 1: the path is always exported and the UI confirmation is shown,
+ *                  which lets us check the formatted derivation path.
+ * On success we compare the returned status word and (when pinned) the exact
+ * base58 pubkey. A case with `error` set expects that status word for both
+ * display values.
+ *
+ * BIP32 derivation is real (app crypto over the speculos bridge, which uses the
+ * standard test seed), so no device or emulator is needed.
+ */
+#include <limits.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <setjmp.h>
+
+#include <cmocka.h>
+
+#include "mock_dispatcher.h"
+#include "tomlc17.h"
+#include "toml_helpers.h"
+
+#include "buffer.h"
+#include "write.h"
+#include "constants.h"
+#include "handler/handlers.h"
+#include "sw.h"
+#include "ui/display.h"  // ui_display_pubkey
+
+#ifndef TEST_VECTORS_PATH
+#error "TEST_VECTORS_PATH must be defined to point at the vectors file"
+#endif
+
+#define MAX_NAME_LEN  64
+#define MAX_PATH_LEN  128
+#define MAX_ERROR_LEN 32
+/* A few extra slots so the over-long-path vector still parses and is rejected
+ * by the length check inside the handler. */
+#define MAX_PATH_STEPS (MAX_BIP32_PATH_STEPS + 6)
+
+typedef struct {
+    char name[MAX_NAME_LEN];
+    char path[MAX_PATH_LEN];
+    bool standard;
+    bool has_error;
+    char error[MAX_ERROR_LEN];
+    bool has_pubkey;
+    char expected_pubkey[MAX_SERIALIZED_PUBKEY_LENGTH + 1];
+} testcase_t;
+
+static testcase_t *g_cases = NULL;
+static size_t g_n_cases = 0;
+
+/* Records the arguments the handler passes to the UI confirmation, so the test
+ * can verify the formatted path and that the displayed pubkey matches the one
+ * returned to the host. Reset before each handler run. */
+static struct {
+    bool called;
+    char path_str[MAX_SERIALIZED_BIP32_PATH_LENGTH + 1];
+    char pubkey[MAX_SERIALIZED_PUBKEY_LENGTH + 1];
+} g_ui_capture;
+
+/* The handler shows this when display = 1; we capture and approve. Pure UI
+ * approve/reject flows are out of scope for these vectors (see the .toml). */
+bool ui_display_pubkey(dispatcher_context_t *context,
+                       const char *bip32_path_str,
+                       const char *pubkey) {
+    (void) context;
+    g_ui_capture.called = true;
+    snprintf(g_ui_capture.path_str, sizeof(g_ui_capture.path_str), "%s", bip32_path_str);
+    snprintf(g_ui_capture.pubkey, sizeof(g_ui_capture.pubkey), "%s", pubkey);
+    return true;
+}
+
+/* ===========================================================================
+ *  TOML loader. Copies the relevant fields out of the parsed document into
+ *  g_cases. Runs from main() before any test, so on malformed input we
+ *  abort() the process (there is no setjmp buffer to unwind to yet).
+ * =========================================================================== */
+static void parse_vectors(const char *path) {
+    toml_result_t r = toml_parse_file_ex(path);
+    if (!r.ok) {
+        fprintf(stderr, "failed to parse %s: %s\n", path, r.errmsg);
+        toml_free(r);
+        abort();
+    }
+
+    toml_datum_t cases = toml_get(r.toptab, "case");
+    if (cases.type != TOML_ARRAY) {
+        fprintf(stderr, "vectors file is missing the [[case]] array\n");
+        toml_free(r);
+        abort();
+    }
+
+    if (cases.u.arr.size <= 0) {
+        fprintf(stderr, "vectors file has no [[case]] entries\n");
+        abort();
+    }
+
+    g_n_cases = (size_t) cases.u.arr.size;
+    g_cases = calloc(g_n_cases, sizeof(testcase_t));
+    if (g_cases == NULL) {
+        fprintf(stderr, "out of memory allocating %zu test cases\n", g_n_cases);
+        abort();
+    }
+
+    for (size_t i = 0; i < g_n_cases; i++) {
+        toml_datum_t tc_node = cases.u.arr.elem[i];
+        if (tc_node.type != TOML_TABLE) {
+            fprintf(stderr, "case %zu: not a TOML table\n", i);
+            abort();
+        }
+
+        testcase_t *cur = &g_cases[i];
+
+        copy_required_string(tc_node, "name", cur->name, sizeof(cur->name));
+        copy_required_string(tc_node, "path", cur->path, sizeof(cur->path));
+
+        toml_datum_t standard = toml_get(tc_node, "standard");
+        if (standard.type != TOML_BOOLEAN) {
+            fprintf(stderr, "%s: missing or non-boolean field: standard\n", cur->name);
+            abort();
+        }
+        cur->standard = standard.u.boolean;
+
+        cur->has_error = copy_optional_string(tc_node, "error", cur->error, sizeof(cur->error));
+        cur->has_pubkey = copy_optional_string(tc_node,
+                                               "expected_pubkey",
+                                               cur->expected_pubkey,
+                                               sizeof(cur->expected_pubkey));
+    }
+
+    toml_free(r);
+}
+
+/* ===========================================================================
+ *  Helpers
+ * =========================================================================== */
+
+/* Parse a textual derivation path ("m", "m/44'/1'/0'", ...) into a uint32_t
+ * array, OR-ing 0x80000000 onto hardened steps (suffix ' or h). Aborts on a
+ * malformed path or one with more than MAX_PATH_STEPS steps. */
+static size_t parse_bip32_path(const char *str, uint32_t out[MAX_PATH_STEPS]) {
+    if (str[0] != 'm') {
+        fprintf(stderr, "path %s does not start with 'm'\n", str);
+        abort();
+    }
+    const char *p = str + 1;
+    size_t n = 0;
+    while (*p == '/') {
+        p++;  // skip '/'
+        if (*p < '0' || *p > '9') {
+            fprintf(stderr, "path %s: expected a number after '/'\n", str);
+            abort();
+        }
+        uint32_t value = 0;
+        while (*p >= '0' && *p <= '9') {
+            value = value * 10 + (uint32_t) (*p - '0');
+            p++;
+        }
+        if (*p == '\'' || *p == 'h' || *p == 'H') {
+            value |= 0x80000000u;
+            p++;
+        }
+        if (n >= MAX_PATH_STEPS) {
+            fprintf(stderr, "path %s: too many steps\n", str);
+            abort();
+        }
+        out[n++] = value;
+    }
+    if (*p != '\0') {
+        fprintf(stderr, "path %s: unexpected trailing characters '%s'\n", str, p);
+        abort();
+    }
+    return n;
+}
+
+/* The human-readable path bip32_path_format produces: the input path without
+ * the leading "m/" (it uses the same "'" hardened marker our vectors do), or
+ * "(Master key)" for the empty path. */
+static const char *expected_path_str(const char *path) {
+    if (strcmp(path, "m") == 0) {
+        return "(Master key)";
+    }
+    return path + 2;  // skip "m/"
+}
+
+/* Map an error name from the vectors file to its status word. */
+static uint16_t error_name_to_sw(const char *name) {
+    if (strcmp(name, "NOT_SUPPORTED") == 0) {
+        return SW_NOT_SUPPORTED;
+    }
+    if (strcmp(name, "INCORRECT_DATA") == 0) {
+        return SW_INCORRECT_DATA;
+    }
+    fprintf(stderr, "unknown error name: %s\n", name);
+    abort();
+}
+
+/* ===========================================================================
+ *  Test driver
+ * =========================================================================== */
+
+/* Per-case cmocka state: pairs a heap-allocated mock dispatcher with the
+ * testcase. Mirrors test_register_wallet.c / test_sign_message.c. */
+typedef struct {
+    void *mock_state;
+    const testcase_t *tc;
+} case_state_t;
+
+static int case_setup(void **state) {
+    const testcase_t *tc = (const testcase_t *) *state;
+    case_state_t *cs = calloc(1, sizeof(case_state_t));
+    if (cs == NULL) {
+        return -1;
+    }
+    if (mock_dispatcher_setup(&cs->mock_state) != 0) {
+        free(cs);
+        return -1;
+    }
+    cs->tc = tc;
+    *state = cs;
+    return 0;
+}
+
+static int case_teardown(void **state) {
+    case_state_t *cs = *state;
+    if (cs != NULL) {
+        mock_dispatcher_teardown(&cs->mock_state);
+        free(cs);
+        *state = NULL;
+    }
+    return 0;
+}
+
+/* Build the command data, reset the mock and the UI capture, run the handler,
+ * and return the status word plus the (NUL-terminated) response bytes. */
+static void run_handler(mock_dispatcher_t *mock,
+                        const testcase_t *tc,
+                        uint8_t display,
+                        uint16_t *sw,
+                        char *resp,
+                        size_t resp_size) {
+    mock_dispatcher_init(mock);
+    memset(&g_ui_capture, 0, sizeof(g_ui_capture));
+
+    uint32_t path[MAX_PATH_STEPS];
+    size_t path_len = parse_bip32_path(tc->path, path);
+
+    uint8_t cdata[2 + 4 * MAX_PATH_STEPS];
+    size_t off = 0;
+    cdata[off++] = display;
+    cdata[off++] = (uint8_t) path_len;
+    for (size_t i = 0; i < path_len; i++) {
+        write_u32_be(cdata, off, path[i]);
+        off += 4;
+    }
+
+    mock->dc.read_buffer = buffer_create(cdata, off);
+    handler_get_extended_pubkey(&mock->dc, 0);
+
+    *sw = mock->last_sw;
+    size_t n = mock->request_len < resp_size - 1 ? mock->request_len : resp_size - 1;
+    memcpy(resp, mock->request_buf, n);
+    resp[n] = '\0';
+}
+
+static void test_one_case(void **state) {
+    case_state_t *cs = *state;
+    mock_dispatcher_t *mock = cs->mock_state;
+    const testcase_t *tc = cs->tc;
+
+    char resp[MAX_SERIALIZED_PUBKEY_LENGTH + 2];
+    uint16_t sw;
+
+    if (tc->has_error) {
+        /* The error is reported regardless of the display flag (e.g. an
+         * over-max path is rejected before the export/UI step). */
+        uint16_t err = error_name_to_sw(tc->error);
+        run_handler(mock, tc, 0, &sw, resp, sizeof(resp));
+        assert_int_equal(sw, err);
+        assert_false(g_ui_capture.called);
+        run_handler(mock, tc, 1, &sw, resp, sizeof(resp));
+        assert_int_equal(sw, err);
+        assert_false(g_ui_capture.called);
+        return;
+    }
+
+    /* display = 0: behaviour is governed by the `standard` flag. */
+    run_handler(mock, tc, 0, &sw, resp, sizeof(resp));
+    if (tc->standard) {
+        assert_int_equal(sw, SW_OK);
+        if (tc->has_pubkey) {
+            assert_string_equal(resp, tc->expected_pubkey);
+        }
+        assert_false(g_ui_capture.called);  // exported without confirmation
+    } else {
+        assert_int_equal(sw, SW_NOT_SUPPORTED);
+        assert_false(g_ui_capture.called);
+    }
+
+    /* display = 1: always exported, and the UI confirmation is shown — which
+     * lets us check the formatted path and that the displayed pubkey matches
+     * the one returned to the host. */
+    run_handler(mock, tc, 1, &sw, resp, sizeof(resp));
+    assert_int_equal(sw, SW_OK);
+    if (tc->has_pubkey) {
+        assert_string_equal(resp, tc->expected_pubkey);
+    }
+    assert_true(g_ui_capture.called);
+    assert_string_equal(g_ui_capture.path_str, expected_path_str(tc->path));
+    assert_string_equal(g_ui_capture.pubkey, resp);
+}
+
+int main(void) {
+    parse_vectors(TEST_VECTORS_PATH);
+
+    /* VLA so that the cmocka_run_group_tests_name macro's sizeof-based
+     * count computes correctly; a calloc'd pointer would not. */
+    struct CMUnitTest tests[g_n_cases];
+    for (size_t i = 0; i < g_n_cases; i++) {
+        tests[i] = (struct CMUnitTest){
+            .name = g_cases[i].name,
+            .test_func = test_one_case,
+            .setup_func = case_setup,
+            .teardown_func = case_teardown,
+            .initial_state = &g_cases[i],
+        };
+    }
+
+    int rc = cmocka_run_group_tests_name("get_extended_pubkey", tests, NULL, NULL);
+    free(g_cases);
+    return rc;
+}

--- a/unit-tests/test_get_wallet_address.c
+++ b/unit-tests/test_get_wallet_address.c
@@ -24,6 +24,7 @@
 
 #include "mock_dispatcher.h"
 #include "tomlc17.h"
+#include "toml_helpers.h"
 
 #include "common/wallet.h"
 #include "handler/lib/policy.h"
@@ -57,49 +58,6 @@ static size_t g_n_cases = 0;
  *  TOML loader. Copies the relevant fields out of the parsed document into
  *  g_cases, so the document lifetime doesn't need to outlive parsing.
  * =========================================================================== */
-
-/* The TOML loader runs from main() before cmocka_run_group_tests_name(),
- * so there is no active test (and no setjmp buffer) for cmocka's fail()
- * / assert_* macros to unwind to. On malformed input we abort() the
- * process instead, which gives a deterministic, non-zero exit. */
-
-/* Copy a required string field from a TOML table into a fixed-size buffer.
- * Aborts the process if the field is missing or doesn't fit. */
-static void copy_required_string(toml_datum_t table,
-                                 const char *key,
-                                 char *dst,
-                                 size_t dst_size) {
-    toml_datum_t d = toml_get(table, key);
-    if (d.type != TOML_STRING) {
-        fprintf(stderr, "missing or non-string field: %s\n", key);
-        abort();
-    }
-    if ((size_t) d.u.str.len >= dst_size) {
-        fprintf(stderr, "field %s too long (%d >= %zu)\n", key, d.u.str.len, dst_size);
-        abort();
-    }
-    memcpy(dst, d.u.str.ptr, (size_t) d.u.str.len);
-    dst[d.u.str.len] = '\0';
-}
-
-/* Copy a required non-negative integer field. */
-static unsigned int copy_required_uint(toml_datum_t table, const char *key) {
-    toml_datum_t d = toml_get(table, key);
-    if (d.type != TOML_INT64) {
-        fprintf(stderr, "missing or non-integer field: %s\n", key);
-        abort();
-    }
-    if (d.u.int64 < 0) {
-        fprintf(stderr, "negative integer in field: %s\n", key);
-        abort();
-    }
-    if (d.u.int64 > UINT_MAX) {
-        fprintf(stderr, "integer in field %s too large\n", key);
-        abort();
-    }
-    return (unsigned int) d.u.int64;
-}
-
 static void parse_vectors(const char *path) {
     toml_result_t r = toml_parse_file_ex(path);
     if (!r.ok) {
@@ -246,8 +204,8 @@ static void test_one_case(void **state) {
     memcpy(keys_merkle_root, mock->trees[mock->n_trees - 1].root, 32);
 
     uint8_t policy_buf[MAX_WALLET_POLICY_BYTES];
-    buffer_t tpl_buf = buffer_create((void *) tc->descriptor_template,
-                                     strlen(tc->descriptor_template));
+    buffer_t tpl_buf =
+        buffer_create((void *) tc->descriptor_template, strlen(tc->descriptor_template));
     int parse_res = parse_descriptor_template(&tpl_buf,
                                               policy_buf,
                                               sizeof(policy_buf),

--- a/unit-tests/test_register_wallet.c
+++ b/unit-tests/test_register_wallet.c
@@ -1,0 +1,403 @@
+/**
+ * Unit tests for handler_register_wallet (and, indirectly, its static helpers
+ * is_policy_acceptable / is_policy_name_acceptable).
+ *
+ * Test cases are loaded from TEST_VECTORS_PATH (a TOML file) at runtime; see
+ * the file's header comment for the schema. For each vector we:
+ *   1. Register the descriptor template as a preimage and the keys-info list as
+ *      a Merkle tree with the mock dispatcher (this gives us the keys Merkle
+ *      root the device would have received from the client).
+ *   2. Serialize the register_wallet command data exactly as the Python
+ *      command_builder does: varint(len(wallet_bytes)) || wallet_bytes.
+ *   3. Drive handler_register_wallet against the mock dispatcher.
+ *   4. On success, assert the returned status word is OK and that the response
+ *      (wallet_id || hmac) matches the pinned expected_wallet_id and, when
+ *      present, expected_wallet_hmac.
+ *      On a deterministic rejection, assert the mapped status word.
+ *
+ * BIP32 derivation and the SLIP-0021 wallet HMAC are real (app crypto over the
+ * speculos bridge, which uses the standard test seed), so the pinned wallet
+ * HMACs reproduce without a device or emulator.
+ *
+ * A final, hand-written case (not from the vectors file) checks the
+ * SW_WRONG_DATA_LENGTH framing branch, which the portable wallet-policy schema
+ * cannot express.
+ */
+#include <limits.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <setjmp.h>
+
+#include <cmocka.h>
+
+#include "cx.h"
+
+#include "mock_dispatcher.h"
+#include "tomlc17.h"
+#include "toml_helpers.h"
+
+#include "buffer.h"
+#include "varint.h"
+#include "common/wallet.h"
+#include "constants.h"
+#include "handler/handlers.h"
+#include "sw.h"
+#include "ui/display.h"  // key_type_e, ui_display_register_wallet_policy
+
+#ifndef TEST_VECTORS_PATH
+#error "TEST_VECTORS_PATH must be defined to point at the vectors file"
+#endif
+
+#define MAX_KEYS_PER_CASE 16
+#define MAX_KEY_INFO_LEN  (MAX_POLICY_KEY_INFO_LEN + 1)
+#define MAX_TPL_LEN       (MAX_DESCRIPTOR_TEMPLATE_LENGTH_V2 + 1)
+/* One slot more than MAX_WALLET_NAME_LENGTH so the over-long-name reject vector
+ * still fits in the buffer (the handler is what rejects it, not the loader). */
+#define MAX_NAME_LEN      (MAX_WALLET_NAME_LENGTH + 2)
+#define MAX_ERROR_LEN     32
+#define HASH_HEX_LEN      64
+
+typedef struct {
+    char name[MAX_NAME_LEN];
+    char descriptor_template[MAX_TPL_LEN];
+    char keys_info[MAX_KEYS_PER_CASE][MAX_KEY_INFO_LEN];
+    size_t n_keys;
+    char wallet_name[MAX_NAME_LEN];
+    bool has_error;
+    char error[MAX_ERROR_LEN];
+    bool has_wallet_id;
+    uint8_t expected_wallet_id[32];
+    bool has_wallet_hmac;
+    uint8_t expected_wallet_hmac[32];
+} testcase_t;
+
+static testcase_t *g_cases = NULL;
+static size_t g_n_cases = 0;
+
+/* The handler references the UI confirmation; we exercise the UI-free flow, so
+ * this stub only needs to satisfy the linker (it always approves). Pure UI
+ * DENY flows are out of scope for these vectors (see register_wallet.toml). */
+bool ui_display_register_wallet_policy(
+    dispatcher_context_t *context,
+    const policy_map_wallet_header_t *wallet_header,
+    const char *descriptor_template,
+    const char (*keys_info)[MAX_N_KEYS_IN_WALLET_POLICY][MAX_POLICY_KEY_INFO_LEN + 1],
+    const key_type_e (*keys_type)[MAX_N_KEYS_IN_WALLET_POLICY]) {
+    (void) context;
+    (void) wallet_header;
+    (void) descriptor_template;
+    (void) keys_info;
+    (void) keys_type;
+    return true;
+}
+
+/* ===========================================================================
+ *  Helpers
+ * =========================================================================== */
+
+/* Decode exactly 64 lowercase/uppercase hex chars into 32 bytes. Aborts on a
+ * bad length or a non-hex character (runs before any test, so abort() is the
+ * right failure mode — there is no setjmp buffer to unwind to). */
+static void decode_hash_hex(const char *field, const char *hex, uint8_t out[32]) {
+    if (strlen(hex) != HASH_HEX_LEN) {
+        fprintf(stderr, "%s: expected %d hex chars, got %zu\n", field, HASH_HEX_LEN, strlen(hex));
+        abort();
+    }
+    for (size_t i = 0; i < 32; i++) {
+        unsigned int byte;
+        if (sscanf(hex + 2 * i, "%2x", &byte) != 1) {
+            fprintf(stderr, "%s: invalid hex\n", field);
+            abort();
+        }
+        out[i] = (uint8_t) byte;
+    }
+}
+
+/* Map an error name from the vectors file to its status word. */
+static uint16_t error_name_to_sw(const char *name) {
+    if (strcmp(name, "NOT_SUPPORTED") == 0) {
+        return SW_NOT_SUPPORTED;
+    }
+    if (strcmp(name, "INCORRECT_DATA") == 0) {
+        return SW_INCORRECT_DATA;
+    }
+    fprintf(stderr, "unknown error name: %s\n", name);
+    abort();
+}
+
+/* ===========================================================================
+ *  TOML loader. Copies the relevant fields out of the parsed document into
+ *  g_cases, so the document lifetime doesn't need to outlive parsing.
+ * =========================================================================== */
+static void parse_vectors(const char *path) {
+    toml_result_t r = toml_parse_file_ex(path);
+    if (!r.ok) {
+        fprintf(stderr, "failed to parse %s: %s\n", path, r.errmsg);
+        toml_free(r);
+        abort();
+    }
+
+    toml_datum_t cases = toml_get(r.toptab, "case");
+    if (cases.type != TOML_ARRAY) {
+        fprintf(stderr, "vectors file is missing the [[case]] array\n");
+        toml_free(r);
+        abort();
+    }
+
+    if (cases.u.arr.size <= 0) {
+        fprintf(stderr, "vectors file has no [[case]] entries\n");
+        abort();
+    }
+
+    g_n_cases = (size_t) cases.u.arr.size;
+    g_cases = calloc(g_n_cases, sizeof(testcase_t));
+    if (g_cases == NULL) {
+        fprintf(stderr, "out of memory allocating %zu test cases\n", g_n_cases);
+        abort();
+    }
+
+    for (size_t i = 0; i < g_n_cases; i++) {
+        toml_datum_t tc_node = cases.u.arr.elem[i];
+        if (tc_node.type != TOML_TABLE) {
+            fprintf(stderr, "case %zu: not a TOML table\n", i);
+            abort();
+        }
+
+        testcase_t *cur = &g_cases[i];
+
+        copy_required_string(tc_node, "name", cur->name, sizeof(cur->name));
+        copy_required_string(tc_node,
+                             "descriptor_template",
+                             cur->descriptor_template,
+                             sizeof(cur->descriptor_template));
+
+        /* wallet_name defaults to "" (empty). */
+        if (!copy_optional_string(tc_node,
+                                  "wallet_name",
+                                  cur->wallet_name,
+                                  sizeof(cur->wallet_name))) {
+            cur->wallet_name[0] = '\0';
+        }
+
+        char hex[HASH_HEX_LEN + 1];
+        cur->has_wallet_id = copy_optional_string(tc_node, "expected_wallet_id", hex, sizeof(hex));
+        if (cur->has_wallet_id) {
+            decode_hash_hex("expected_wallet_id", hex, cur->expected_wallet_id);
+        }
+        cur->has_wallet_hmac =
+            copy_optional_string(tc_node, "expected_wallet_hmac", hex, sizeof(hex));
+        if (cur->has_wallet_hmac) {
+            decode_hash_hex("expected_wallet_hmac", hex, cur->expected_wallet_hmac);
+        }
+
+        cur->has_error = copy_optional_string(tc_node, "error", cur->error, sizeof(cur->error));
+
+        if (cur->has_error == cur->has_wallet_id) {
+            fprintf(stderr,
+                    "%s: must have exactly one of `error` or `expected_wallet_id`\n",
+                    cur->name);
+            abort();
+        }
+
+        toml_datum_t keys = toml_get(tc_node, "keys_info");
+        if (keys.type != TOML_ARRAY) {
+            fprintf(stderr, "%s: keys_info must be an array\n", cur->name);
+            abort();
+        }
+        if (keys.u.arr.size <= 0 || (size_t) keys.u.arr.size > MAX_KEYS_PER_CASE) {
+            fprintf(stderr,
+                    "%s: keys_info has %d entries (must be 1..%d)\n",
+                    cur->name,
+                    keys.u.arr.size,
+                    MAX_KEYS_PER_CASE);
+            abort();
+        }
+        cur->n_keys = (size_t) keys.u.arr.size;
+
+        for (size_t k = 0; k < cur->n_keys; k++) {
+            toml_datum_t key_node = keys.u.arr.elem[k];
+            if (key_node.type != TOML_STRING) {
+                fprintf(stderr, "%s: keys_info[%zu] is not a string\n", cur->name, k);
+                abort();
+            }
+            if ((size_t) key_node.u.str.len >= MAX_KEY_INFO_LEN) {
+                fprintf(stderr,
+                        "%s: keys_info[%zu] too long (%d >= %d)\n",
+                        cur->name,
+                        k,
+                        key_node.u.str.len,
+                        MAX_KEY_INFO_LEN);
+                abort();
+            }
+            memcpy(cur->keys_info[k], key_node.u.str.ptr, (size_t) key_node.u.str.len);
+            cur->keys_info[k][key_node.u.str.len] = '\0';
+        }
+    }
+
+    toml_free(r);
+}
+
+/* ===========================================================================
+ *  Test driver
+ * =========================================================================== */
+
+/* Per-case cmocka state: pairs a heap-allocated mock dispatcher with the
+ * testcase. Mirrors test_get_wallet_address.c. */
+typedef struct {
+    void *mock_state;
+    const testcase_t *tc;
+} case_state_t;
+
+static int case_setup(void **state) {
+    const testcase_t *tc = (const testcase_t *) *state;
+    case_state_t *cs = calloc(1, sizeof(case_state_t));
+    if (cs == NULL) {
+        return -1;
+    }
+    if (mock_dispatcher_setup(&cs->mock_state) != 0) {
+        free(cs);
+        return -1;
+    }
+    cs->tc = tc;
+    *state = cs;
+    return 0;
+}
+
+static int case_teardown(void **state) {
+    case_state_t *cs = *state;
+    if (cs != NULL) {
+        mock_dispatcher_teardown(&cs->mock_state);
+        free(cs);
+        *state = NULL;
+    }
+    return 0;
+}
+
+/* Serialize the register_wallet command data into `out`, returning its length.
+ * Layout matches command_builder.register_wallet:
+ *   varint(len(wallet_bytes)) || wallet_bytes
+ * with wallet_bytes =
+ *   version(1) || name_len(1) || name || varint(template_len) ||
+ *   sha256(template) || varint(n_keys) || keys_merkle_root(32). */
+static size_t serialize_request(const testcase_t *tc,
+                                const uint8_t keys_merkle_root[32],
+                                uint8_t *out,
+                                size_t out_size) {
+    uint8_t wb[1 + 1 + MAX_NAME_LEN + 5 + 32 + 5 + 32];
+    size_t wblen = 0;
+
+    size_t name_len = strlen(tc->wallet_name);
+    size_t template_len = strlen(tc->descriptor_template);
+
+    wb[wblen++] = WALLET_POLICY_VERSION_V2;
+    wb[wblen++] = (uint8_t) name_len;
+    memcpy(wb + wblen, tc->wallet_name, name_len);
+    wblen += name_len;
+
+    wblen += (size_t) varint_write(wb + wblen, 0, template_len);
+
+    cx_hash_sha256((const uint8_t *) tc->descriptor_template, template_len, wb + wblen, 32);
+    wblen += 32;
+
+    wblen += (size_t) varint_write(wb + wblen, 0, tc->n_keys);
+
+    memcpy(wb + wblen, keys_merkle_root, 32);
+    wblen += 32;
+
+    size_t clen = 0;
+    clen += (size_t) varint_write(out, 0, wblen);
+    assert_true(clen + wblen <= out_size);
+    memcpy(out + clen, wb, wblen);
+    clen += wblen;
+    return clen;
+}
+
+static void test_one_case(void **state) {
+    case_state_t *cs = *state;
+    mock_dispatcher_t *mock = cs->mock_state;
+    const testcase_t *tc = cs->tc;
+
+    /* The descriptor template is fetched by the device via call_get_preimage. */
+    mock_dispatcher_add_preimage(mock,
+                                 (const uint8_t *) tc->descriptor_template,
+                                 strlen(tc->descriptor_template));
+
+    /* Register the keys-info list; the last tree's root is the keys Merkle root
+     * the device would have received in the wallet header. */
+    const uint8_t *key_ptrs[MAX_KEYS_PER_CASE];
+    size_t key_lens[MAX_KEYS_PER_CASE];
+    for (size_t i = 0; i < tc->n_keys; i++) {
+        key_ptrs[i] = (const uint8_t *) tc->keys_info[i];
+        key_lens[i] = strlen(tc->keys_info[i]);
+    }
+    mock_dispatcher_add_list(mock, key_ptrs, key_lens, tc->n_keys);
+    uint8_t keys_merkle_root[32];
+    memcpy(keys_merkle_root, mock->trees[mock->n_trees - 1].root, 32);
+
+    uint8_t cdata[MAX_TPL_LEN + 128];
+    size_t cdata_len = serialize_request(tc, keys_merkle_root, cdata, sizeof(cdata));
+
+    dispatcher_context_t *dc = mock_dispatcher_get_dc(mock);
+    dc->read_buffer = buffer_create(cdata, cdata_len);
+
+    handler_register_wallet(dc, 0);
+
+    if (tc->has_error) {
+        assert_int_equal(mock->last_sw, error_name_to_sw(tc->error));
+        return;
+    }
+
+    /* Success: response is wallet_id(32) || hmac(32), accumulated in request_buf. */
+    assert_int_equal(mock->last_sw, SW_OK);
+    assert_int_equal(mock->request_len, 64);
+    assert_memory_equal(mock->request_buf, tc->expected_wallet_id, 32);
+    if (tc->has_wallet_hmac) {
+        assert_memory_equal(mock->request_buf + 32, tc->expected_wallet_hmac, 32);
+    }
+}
+
+/* Hand-written framing case: an empty command buffer makes the leading
+ * buffer_read_varint fail, which the handler reports as SW_WRONG_DATA_LENGTH.
+ * This branch can't be expressed via the portable wallet-policy schema. */
+static void test_wrong_data_length(void **state) {
+    mock_dispatcher_t *mock = *state;
+    dispatcher_context_t *dc = mock_dispatcher_get_dc(mock);
+
+    dc->read_buffer = buffer_create((void *) "", 0);
+    handler_register_wallet(dc, 0);
+
+    assert_int_equal(mock->last_sw, SW_WRONG_DATA_LENGTH);
+}
+
+int main(void) {
+    parse_vectors(TEST_VECTORS_PATH);
+
+    /* VLA so that the cmocka_run_group_tests_name macro's sizeof-based count
+     * computes correctly; the +1 is the hand-written framing case. */
+    struct CMUnitTest tests[g_n_cases + 1];
+    for (size_t i = 0; i < g_n_cases; i++) {
+        tests[i] = (struct CMUnitTest){
+            .name = g_cases[i].name,
+            .test_func = test_one_case,
+            .setup_func = case_setup,
+            .teardown_func = case_teardown,
+            .initial_state = &g_cases[i],
+        };
+    }
+    tests[g_n_cases] = (struct CMUnitTest){
+        .name = "wrong_data_length",
+        .test_func = test_wrong_data_length,
+        .setup_func = mock_dispatcher_setup,
+        .teardown_func = mock_dispatcher_teardown,
+        .initial_state = NULL,
+    };
+
+    int rc = cmocka_run_group_tests_name("register_wallet", tests, NULL, NULL);
+    free(g_cases);
+    return rc;
+}

--- a/unit-tests/test_register_wallet.c
+++ b/unit-tests/test_register_wallet.c
@@ -74,26 +74,63 @@ typedef struct {
     uint8_t expected_wallet_id[32];
     bool has_wallet_hmac;
     uint8_t expected_wallet_hmac[32];
+    bool has_key_types;
+    key_type_e key_types[MAX_KEYS_PER_CASE];
+    size_t n_key_types;
 } testcase_t;
 
 static testcase_t *g_cases = NULL;
 static size_t g_n_cases = 0;
 
-/* The handler references the UI confirmation; we exercise the UI-free flow, so
- * this stub only needs to satisfy the linker (it always approves). Pure UI
- * DENY flows are out of scope for these vectors (see register_wallet.toml). */
+/* Records the arguments the handler passes to the UI confirmation, so the test
+ * can verify the per-key classification (internal/external/unspendable) the
+ * handler computed — not just the aggregate status word. Reset before each case
+ * in case_setup. A file-scope global is the channel: the stub's signature is
+ * fixed by the UI prototype, and the shared mock dispatcher shouldn't carry
+ * test-specific fields. */
+static struct {
+    bool called;
+    size_t n_keys;
+    key_type_e keys_type[MAX_N_KEYS_IN_WALLET_POLICY];
+    char descriptor_template[MAX_TPL_LEN];
+    char name[MAX_NAME_LEN];
+    uint8_t version;
+} g_ui_capture;
+
+/* The handler calls this once the policy is accepted, just before computing the
+ * HMAC. We capture its arguments and approve (return true); pure UI DENY flows
+ * are out of scope for these vectors (see register_wallet.toml). */
 bool ui_display_register_wallet_policy(
     dispatcher_context_t *context,
     const policy_map_wallet_header_t *wallet_header,
     const char *descriptor_template,
     const char (*keys_info)[MAX_N_KEYS_IN_WALLET_POLICY][MAX_POLICY_KEY_INFO_LEN + 1],
     const key_type_e (*keys_type)[MAX_N_KEYS_IN_WALLET_POLICY]) {
-    (void) context;
-    (void) wallet_header;
-    (void) descriptor_template;
     (void) keys_info;
-    (void) keys_type;
+
+    g_ui_capture.called = true;
+    g_ui_capture.n_keys = wallet_header->n_keys;
+    g_ui_capture.version = wallet_header->version;
+    for (size_t i = 0; i < wallet_header->n_keys && i < MAX_N_KEYS_IN_WALLET_POLICY; i++) {
+        g_ui_capture.keys_type[i] = (*keys_type)[i];
+    }
+    snprintf(g_ui_capture.name, sizeof(g_ui_capture.name), "%s", wallet_header->name);
+    snprintf(g_ui_capture.descriptor_template,
+             sizeof(g_ui_capture.descriptor_template),
+             "%s",
+             descriptor_template);
+
+    (void) context;
     return true;
+}
+
+/* Map a key-type name from the vectors file to its key_type_e. */
+static key_type_e key_type_from_name(const char *name) {
+    if (strcmp(name, "internal") == 0) return PUBKEY_TYPE_INTERNAL;
+    if (strcmp(name, "external") == 0) return PUBKEY_TYPE_EXTERNAL;
+    if (strcmp(name, "unspendable") == 0) return PUBKEY_TYPE_UNSPENDABLE;
+    fprintf(stderr, "unknown key type: %s\n", name);
+    abort();
 }
 
 /* ===========================================================================
@@ -237,6 +274,28 @@ static void parse_vectors(const char *path) {
             memcpy(cur->keys_info[k], key_node.u.str.ptr, (size_t) key_node.u.str.len);
             cur->keys_info[k][key_node.u.str.len] = '\0';
         }
+
+        /* Optional per-key classification (one entry per key, @0,@1,... order). */
+        toml_datum_t kt = toml_get(tc_node, "expected_key_types");
+        cur->has_key_types = (kt.type != TOML_UNKNOWN);
+        if (cur->has_key_types) {
+            if (kt.type != TOML_ARRAY || (size_t) kt.u.arr.size != cur->n_keys) {
+                fprintf(stderr,
+                        "%s: expected_key_types must be an array of length n_keys (%zu)\n",
+                        cur->name,
+                        cur->n_keys);
+                abort();
+            }
+            cur->n_key_types = cur->n_keys;
+            for (size_t k = 0; k < cur->n_keys; k++) {
+                toml_datum_t e = kt.u.arr.elem[k];
+                if (e.type != TOML_STRING) {
+                    fprintf(stderr, "%s: expected_key_types[%zu] is not a string\n", cur->name, k);
+                    abort();
+                }
+                cur->key_types[k] = key_type_from_name(e.u.str.ptr);
+            }
+        }
     }
 
     toml_free(r);
@@ -265,6 +324,7 @@ static int case_setup(void **state) {
     }
     cs->tc = tc;
     *state = cs;
+    memset(&g_ui_capture, 0, sizeof(g_ui_capture));
     return 0;
 }
 
@@ -349,6 +409,8 @@ static void test_one_case(void **state) {
 
     if (tc->has_error) {
         assert_int_equal(mock->last_sw, error_name_to_sw(tc->error));
+        /* A deterministic rejection must return before the UI confirmation. */
+        assert_false(g_ui_capture.called);
         return;
     }
 
@@ -358,6 +420,21 @@ static void test_one_case(void **state) {
     assert_memory_equal(mock->request_buf, tc->expected_wallet_id, 32);
     if (tc->has_wallet_hmac) {
         assert_memory_equal(mock->request_buf + 32, tc->expected_wallet_hmac, 32);
+    }
+
+    /* The UI confirmation must have been shown, with the parsed header intact. */
+    assert_true(g_ui_capture.called);
+    assert_int_equal(g_ui_capture.version, WALLET_POLICY_VERSION_V2);
+    assert_int_equal(g_ui_capture.n_keys, tc->n_keys);
+    assert_string_equal(g_ui_capture.descriptor_template, tc->descriptor_template);
+    assert_string_equal(g_ui_capture.name, tc->wallet_name);
+
+    /* When pinned, verify the per-key classification (NUMS / internal-key
+     * re-derivation / fingerprint-collision guard) the handler computed. */
+    if (tc->has_key_types) {
+        for (size_t i = 0; i < tc->n_key_types; i++) {
+            assert_int_equal(g_ui_capture.keys_type[i], tc->key_types[i]);
+        }
     }
 }
 

--- a/unit-tests/test_sign_message.c
+++ b/unit-tests/test_sign_message.c
@@ -1,0 +1,483 @@
+/**
+ * Unit tests for handler_sign_message (BIP-137 "Bitcoin Signed Message").
+ *
+ * Test cases are loaded from TEST_VECTORS_PATH (a TOML file) at runtime; see the
+ * file's header comment for the schema. For each vector we:
+ *   1. Split the message into 64-byte (MESSAGE_CHUNK_SIZE) chunks and register
+ *      them as a Merkle list with the mock dispatcher (this is what the device
+ *      streams back via call_get_merkle_leaf_element), keeping the Merkle root.
+ *   2. Serialize the sign_message command data exactly as the Python
+ *      command_builder does: path_len || path || varint(msg_len) || merkle_root.
+ *   3. Drive handler_sign_message against the mock dispatcher.
+ *   4. On success, assert the returned status word is OK and the 65-byte
+ *      recoverable signature matches the pinned base64 `expected_signature`.
+ *      On a deterministic rejection, assert the mapped status word.
+ *
+ * We also capture the arguments the handler passes to the UI confirmation
+ * (ui_display_message_and_confirm) so the test can verify the printable-vs-hash
+ * decision and the formatted derivation path — not just the signature.
+ *
+ * Signing is real (deterministic ECDSA over the speculos bridge, which uses the
+ * standard test seed), so the pinned signatures reproduce without a device.
+ */
+#include <limits.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <setjmp.h>
+
+#include <cmocka.h>
+
+#include "cx.h"
+
+#include "mock_dispatcher.h"
+#include "tomlc17.h"
+#include "toml_helpers.h"
+
+#include "buffer.h"
+#include "varint.h"
+#include "write.h"
+#include "constants.h"
+#include "handler/handlers.h"
+#include "sw.h"
+#include "ui/display.h"  // MESSAGE_CHUNK_SIZE, ui_display_message_and_confirm
+
+#ifndef TEST_VECTORS_PATH
+#error "TEST_VECTORS_PATH must be defined to point at the vectors file"
+#endif
+
+/* Long enough for the largest vector message (~1.6 KB), with margin. */
+#define MAX_MSG_LEN     4096
+#define MAX_PATH_STR    128
+#define MAX_PATH_STEPS  16
+#define MAX_ERROR_LEN   32
+/* base64 of the 65-byte recoverable signature is 88 chars. */
+#define MAX_SIG_B64_LEN 96
+#define SIG_LEN         65
+
+typedef struct {
+    char name[64];
+    uint8_t message[MAX_MSG_LEN];
+    size_t message_len;
+    char path[MAX_PATH_STR];
+    bool has_error;
+    char error[MAX_ERROR_LEN];
+    bool has_signature;
+    uint8_t expected_signature[SIG_LEN];
+    bool has_displayed_as;
+    bool expect_hash;  // true if `displayed_as = "hash"`, false if "message"
+} testcase_t;
+
+static testcase_t *g_cases = NULL;
+static size_t g_n_cases = 0;
+
+/* Records the arguments the handler passes to the UI confirmation, so the test
+ * can verify the printable-vs-hash decision and the formatted path — not just
+ * the signature. Reset before each case in case_setup. */
+static struct {
+    bool called;
+    char path_str[MAX_PATH_STR];
+    char displayed[MAX_MSG_LEN];
+    bool is_hash;
+} g_ui_capture;
+
+/* The handler calls this to confirm the message; we capture and approve. Pure
+ * UI DENY flows are out of scope for these vectors (see sign_message.toml). */
+bool ui_display_message_and_confirm(dispatcher_context_t *context,
+                                    const char *path_str,
+                                    const char *message,
+                                    bool is_hash) {
+    (void) context;
+    g_ui_capture.called = true;
+    g_ui_capture.is_hash = is_hash;
+    snprintf(g_ui_capture.path_str, sizeof(g_ui_capture.path_str), "%s", path_str);
+    snprintf(g_ui_capture.displayed, sizeof(g_ui_capture.displayed), "%s", message);
+    return true;
+}
+
+/* Remaining UI hooks the handler references; linker-only, no behavior needed. */
+void ui_set_processing_screen_text(const char *text) {
+    (void) text;
+}
+bool ui_post_processing_confirm_message(dispatcher_context_t *context, bool success) {
+    (void) context;
+    (void) success;
+    return true;
+}
+const char GA_LOADING_MESSAGE[] = "Loading message";
+
+/* ===========================================================================
+ *  Helpers
+ * =========================================================================== */
+
+/* Decode a standard-alphabet base64 string into `out`, asserting it yields
+ * exactly out_len bytes. Aborts on malformed input (runs before any test). */
+static void decode_base64(const char *field, const char *b64, uint8_t *out, size_t out_len) {
+    static const char alphabet[] =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    int8_t rev[256];
+    memset(rev, -1, sizeof(rev));
+    for (int i = 0; i < 64; i++) rev[(unsigned char) alphabet[i]] = (int8_t) i;
+
+    size_t len = strlen(b64);
+    if (len % 4 != 0) {
+        fprintf(stderr, "%s: base64 length not a multiple of 4\n", field);
+        abort();
+    }
+
+    size_t produced = 0;
+    for (size_t i = 0; i < len; i += 4) {
+        int8_t v[4];
+        int pad = 0;
+        for (int k = 0; k < 4; k++) {
+            char c = b64[i + k];
+            if (c == '=') {
+                v[k] = 0;
+                pad++;
+            } else {
+                v[k] = rev[(unsigned char) c];
+                if (v[k] < 0) {
+                    fprintf(stderr, "%s: invalid base64 char '%c'\n", field, c);
+                    abort();
+                }
+            }
+        }
+        uint32_t triple = ((uint32_t) v[0] << 18) | ((uint32_t) v[1] << 12) |
+                          ((uint32_t) v[2] << 6) | (uint32_t) v[3];
+        uint8_t bytes[3] = {(uint8_t) (triple >> 16), (uint8_t) (triple >> 8), (uint8_t) triple};
+        for (int k = 0; k < 3 - pad; k++) {
+            if (produced >= out_len) {
+                fprintf(stderr, "%s: base64 decodes to more than %zu bytes\n", field, out_len);
+                abort();
+            }
+            out[produced++] = bytes[k];
+        }
+    }
+    if (produced != out_len) {
+        fprintf(stderr, "%s: base64 decoded to %zu bytes (expected %zu)\n", field, produced, out_len);
+        abort();
+    }
+}
+
+/* Map an error name from the vectors file to its status word. */
+static uint16_t error_name_to_sw(const char *name) {
+    if (strcmp(name, "WRONG_DATA_LENGTH") == 0) return SW_WRONG_DATA_LENGTH;
+    if (strcmp(name, "INCORRECT_DATA") == 0) return SW_INCORRECT_DATA;
+    fprintf(stderr, "unknown error name: %s\n", name);
+    abort();
+}
+
+/* Parse a textual derivation path ("m/44'/1'/0'/0/0") into a uint32_t array,
+ * OR-ing 0x80000000 onto hardened steps (suffix ' or h). Returns the step
+ * count. Aborts on a malformed path. */
+static size_t parse_bip32_path(const char *str, uint32_t out[MAX_PATH_STEPS]) {
+    if (str[0] != 'm') {
+        fprintf(stderr, "path %s does not start with 'm'\n", str);
+        abort();
+    }
+    const char *p = str + 1;
+    size_t n = 0;
+    while (*p == '/') {
+        p++;
+        if (*p < '0' || *p > '9') {
+            fprintf(stderr, "path %s: expected a number after '/'\n", str);
+            abort();
+        }
+        uint32_t value = 0;
+        while (*p >= '0' && *p <= '9') {
+            value = value * 10 + (uint32_t) (*p - '0');
+            p++;
+        }
+        if (*p == '\'' || *p == 'h' || *p == 'H') {
+            value |= 0x80000000u;
+            p++;
+        }
+        if (n >= MAX_PATH_STEPS) {
+            fprintf(stderr, "path %s: too many steps\n", str);
+            abort();
+        }
+        out[n++] = value;
+    }
+    if (*p != '\0') {
+        fprintf(stderr, "path %s: unexpected trailing characters '%s'\n", str, p);
+        abort();
+    }
+    return n;
+}
+
+/* The formatted path bip32_path_format produces: the input path without the
+ * leading "m/" (it uses the same "'" hardened marker our vectors do). */
+static const char *expected_path_str(const char *path) {
+    if (strcmp(path, "m") == 0) return "(Master key)";
+    return path + 2;  // skip "m/"
+}
+
+/* ===========================================================================
+ *  TOML loader
+ * =========================================================================== */
+static void parse_vectors(const char *path) {
+    toml_result_t r = toml_parse_file_ex(path);
+    if (!r.ok) {
+        fprintf(stderr, "failed to parse %s: %s\n", path, r.errmsg);
+        toml_free(r);
+        abort();
+    }
+
+    toml_datum_t cases = toml_get(r.toptab, "case");
+    if (cases.type != TOML_ARRAY) {
+        fprintf(stderr, "vectors file is missing the [[case]] array\n");
+        toml_free(r);
+        abort();
+    }
+    if (cases.u.arr.size <= 0) {
+        fprintf(stderr, "vectors file has no [[case]] entries\n");
+        abort();
+    }
+
+    g_n_cases = (size_t) cases.u.arr.size;
+    g_cases = calloc(g_n_cases, sizeof(testcase_t));
+    if (g_cases == NULL) {
+        fprintf(stderr, "out of memory allocating %zu test cases\n", g_n_cases);
+        abort();
+    }
+
+    for (size_t i = 0; i < g_n_cases; i++) {
+        toml_datum_t tc_node = cases.u.arr.elem[i];
+        if (tc_node.type != TOML_TABLE) {
+            fprintf(stderr, "case %zu: not a TOML table\n", i);
+            abort();
+        }
+
+        testcase_t *cur = &g_cases[i];
+
+        copy_required_string(tc_node, "name", cur->name, sizeof(cur->name));
+        copy_required_string(tc_node, "path", cur->path, sizeof(cur->path));
+
+        /* `message` is a (possibly non-ASCII, e.g. \r / \n) UTF-8 string; we
+         * keep its raw bytes. */
+        toml_datum_t msg = toml_get(tc_node, "message");
+        if (msg.type != TOML_STRING) {
+            fprintf(stderr, "%s: missing or non-string field: message\n", cur->name);
+            abort();
+        }
+        if ((size_t) msg.u.str.len > sizeof(cur->message)) {
+            fprintf(stderr, "%s: message too long (%d > %zu)\n",
+                    cur->name, msg.u.str.len, sizeof(cur->message));
+            abort();
+        }
+        cur->message_len = (size_t) msg.u.str.len;
+        memcpy(cur->message, msg.u.str.ptr, cur->message_len);
+
+        char sig_b64[MAX_SIG_B64_LEN];
+        cur->has_signature =
+            copy_optional_string(tc_node, "expected_signature", sig_b64, sizeof(sig_b64));
+        if (cur->has_signature) {
+            decode_base64("expected_signature", sig_b64, cur->expected_signature, SIG_LEN);
+        }
+
+        cur->has_error = copy_optional_string(tc_node, "error", cur->error, sizeof(cur->error));
+
+        if (cur->has_error == cur->has_signature) {
+            fprintf(stderr,
+                    "%s: must have exactly one of `error` or `expected_signature`\n",
+                    cur->name);
+            abort();
+        }
+
+        char displayed_as[16];
+        cur->has_displayed_as =
+            copy_optional_string(tc_node, "displayed_as", displayed_as, sizeof(displayed_as));
+        if (cur->has_displayed_as) {
+            if (strcmp(displayed_as, "hash") == 0) {
+                cur->expect_hash = true;
+            } else if (strcmp(displayed_as, "message") == 0) {
+                cur->expect_hash = false;
+            } else {
+                fprintf(stderr, "%s: displayed_as must be \"message\" or \"hash\"\n", cur->name);
+                abort();
+            }
+        }
+    }
+
+    toml_free(r);
+}
+
+/* ===========================================================================
+ *  Test driver
+ * =========================================================================== */
+typedef struct {
+    void *mock_state;
+    const testcase_t *tc;
+} case_state_t;
+
+static int case_setup(void **state) {
+    const testcase_t *tc = (const testcase_t *) *state;
+    case_state_t *cs = calloc(1, sizeof(case_state_t));
+    if (cs == NULL) return -1;
+    if (mock_dispatcher_setup(&cs->mock_state) != 0) {
+        free(cs);
+        return -1;
+    }
+    cs->tc = tc;
+    *state = cs;
+    memset(&g_ui_capture, 0, sizeof(g_ui_capture));
+    return 0;
+}
+
+static int case_teardown(void **state) {
+    case_state_t *cs = *state;
+    if (cs != NULL) {
+        mock_dispatcher_teardown(&cs->mock_state);
+        free(cs);
+        *state = NULL;
+    }
+    return 0;
+}
+
+/* Serialize the sign_message command data into `out`, returning its length.
+ * Layout matches command_builder.sign_message:
+ *   path_len(1) || path(4*path_len, big-endian) || varint(msg_len) || merkle_root(32). */
+static size_t serialize_request(const uint32_t *path,
+                                size_t path_len,
+                                size_t msg_len,
+                                const uint8_t merkle_root[32],
+                                uint8_t *out) {
+    size_t off = 0;
+    out[off++] = (uint8_t) path_len;
+    for (size_t i = 0; i < path_len; i++) {
+        write_u32_be(out, off, path[i]);
+        off += 4;
+    }
+    off += (size_t) varint_write(out, off, msg_len);
+    memcpy(out + off, merkle_root, 32);
+    off += 32;
+    return off;
+}
+
+/* Uppercase-hex of sha256(message), as the handler builds for the hash display. */
+static void message_hash_hex(const uint8_t *msg, size_t msg_len, char out[65]) {
+    uint8_t h[32];
+    cx_hash_sha256(msg, msg_len, h, 32);
+    for (int i = 0; i < 32; i++) snprintf(out + 2 * i, 3, "%02X", h[i]);
+}
+
+static void test_one_case(void **state) {
+    case_state_t *cs = *state;
+    mock_dispatcher_t *mock = cs->mock_state;
+    const testcase_t *tc = cs->tc;
+
+    uint32_t path[MAX_PATH_STEPS];
+    size_t path_len = parse_bip32_path(tc->path, path);
+
+    /* Split the message into 64-byte chunks and register them as a Merkle list;
+     * the device streams these back via call_get_merkle_leaf_element. */
+    size_t n_chunks = (tc->message_len + MESSAGE_CHUNK_SIZE - 1) / MESSAGE_CHUNK_SIZE;
+    uint8_t merkle_root[32] = {0};
+    if (n_chunks > 0) {
+        const uint8_t *chunk_ptrs[(MAX_MSG_LEN / MESSAGE_CHUNK_SIZE) + 1];
+        size_t chunk_lens[(MAX_MSG_LEN / MESSAGE_CHUNK_SIZE) + 1];
+        for (size_t i = 0; i < n_chunks; i++) {
+            size_t off = i * MESSAGE_CHUNK_SIZE;
+            chunk_ptrs[i] = tc->message + off;
+            chunk_lens[i] = tc->message_len - off < MESSAGE_CHUNK_SIZE
+                                ? tc->message_len - off
+                                : MESSAGE_CHUNK_SIZE;
+        }
+        mock_dispatcher_add_list(mock, chunk_ptrs, chunk_lens, n_chunks);
+        memcpy(merkle_root, mock->trees[mock->n_trees - 1].root, 32);
+    }
+
+    uint8_t cdata[1 + 4 * MAX_PATH_STEPS + 5 + 32];
+    size_t cdata_len = serialize_request(path, path_len, tc->message_len, merkle_root, cdata);
+
+    dispatcher_context_t *dc = mock_dispatcher_get_dc(mock);
+    dc->read_buffer = buffer_create(cdata, cdata_len);
+
+    handler_sign_message(dc, 0);
+
+    if (tc->has_error) {
+        assert_int_equal(mock->last_sw, error_name_to_sw(tc->error));
+        /* A framing/length rejection happens before the UI confirmation. */
+        assert_false(g_ui_capture.called);
+        return;
+    }
+
+    /* Success: response is the 65-byte recoverable signature. */
+    assert_int_equal(mock->last_sw, SW_OK);
+    assert_int_equal(mock->request_len, SIG_LEN);
+    assert_memory_equal(mock->request_buf, tc->expected_signature, SIG_LEN);
+
+    /* The UI confirmation must have been shown with the formatted path. */
+    assert_true(g_ui_capture.called);
+    assert_string_equal(g_ui_capture.path_str, expected_path_str(tc->path));
+
+    /* When pinned, verify the printable-vs-hash decision and the shown text. */
+    if (tc->has_displayed_as) {
+        assert_int_equal(g_ui_capture.is_hash, tc->expect_hash);
+        if (tc->expect_hash) {
+            char hash_hex[65];
+            message_hash_hex(tc->message, tc->message_len, hash_hex);
+            assert_string_equal(g_ui_capture.displayed, hash_hex);
+        } else {
+            assert_int_equal(strlen(g_ui_capture.displayed), tc->message_len);
+            assert_memory_equal(g_ui_capture.displayed, tc->message, tc->message_len);
+        }
+    }
+}
+
+/* Hand-written case: a declared message length of 2^32 trips the explicit
+ * `message_length >= (1LL << 32)` guard -> SW_INCORRECT_DATA, before any chunk
+ * is fetched. The message-based vector schema can't express a 4 GB length, so
+ * this lives in C. */
+static void test_message_too_long(void **state) {
+    mock_dispatcher_t *mock = *state;
+    dispatcher_context_t *dc = mock_dispatcher_get_dc(mock);
+    memset(&g_ui_capture, 0, sizeof(g_ui_capture));
+
+    uint8_t cdata[1 + 4 + 9 + 32];
+    size_t off = 0;
+    cdata[off++] = 1;                              // bip32_path_len
+    write_u32_be(cdata, off, 0x8000002cu);         // 44'
+    off += 4;
+    off += (size_t) varint_write(cdata, off, (uint64_t) 1 << 32);  // message_length
+    memset(cdata + off, 0, 32);                    // merkle root (unused, rejected first)
+    off += 32;
+
+    dc->read_buffer = buffer_create(cdata, off);
+    handler_sign_message(dc, 0);
+
+    assert_int_equal(mock->last_sw, SW_INCORRECT_DATA);
+    assert_false(g_ui_capture.called);
+}
+
+int main(void) {
+    parse_vectors(TEST_VECTORS_PATH);
+
+    /* VLA so the cmocka_run_group_tests_name macro's sizeof-based count works;
+     * the +1 is the hand-written over-long-length case. */
+    struct CMUnitTest tests[g_n_cases + 1];
+    for (size_t i = 0; i < g_n_cases; i++) {
+        tests[i] = (struct CMUnitTest){
+            .name = g_cases[i].name,
+            .test_func = test_one_case,
+            .setup_func = case_setup,
+            .teardown_func = case_teardown,
+            .initial_state = &g_cases[i],
+        };
+    }
+    tests[g_n_cases] = (struct CMUnitTest){
+        .name = "message_too_long",
+        .test_func = test_message_too_long,
+        .setup_func = mock_dispatcher_setup,
+        .teardown_func = mock_dispatcher_teardown,
+        .initial_state = NULL,
+    };
+
+    int rc = cmocka_run_group_tests_name("sign_message", tests, NULL, NULL);
+    free(g_cases);
+    return rc;
+}


### PR DESCRIPTION
Extracts from the TOML test vectors for all the device operations from the python test suites.

Implements C tests for `get_extended_pubkey`, `register_wallet` and `sign_message`.
Since tests for address generation (at least most of it) was added in #493, `sign_psbt` is the only command not covered by C tests (apart from `get_master_fingerprint` that is more ore less trivial).

Some edge cases that were not covered by python tests are now tested.
