### PR TITLE
app-bitcoin-new rename to app-bitcoin

### DIFF
--- a/.github/workflows/builder-image-workflow.yml
+++ b/.github/workflows/builder-image-workflow.yml
@@ -22,7 +22,7 @@ jobs:
       uses: docker/build-push-action@v1
       with:
         dockerfile: .github/workflows/Dockerfile
-        repository: ledgerhq/app-bitcoin-new/speculos-bitcoin
+        repository: ledgerhq/app-bitcoin/speculos-bitcoin
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ It will allow you, whether you are developing on macOS, Windows or Linux to quic
     * On macOS, install and launch [XQuartz](https://www.xquartz.org/) (make sure to go to XQuartz > Preferences > Security and check "Allow client connections").
     * On Windows, install and launch [VcXsrv](https://sourceforge.net/projects/vcxsrv/) (make sure to configure it to disable access control).
 * Install [VScode](https://code.visualstudio.com/download) and add [Ledger's extension](https://marketplace.visualstudio.com/items?itemName=LedgerHQ.ledger-dev-tools).
-* Open a terminal and clone `app-bitcoin-new` with `git clone git@github.com:LedgerHQ/app-bitcoin-new.git`.
-* Open the `app-bitcoin-new` folder with VSCode.
+* Open a terminal and clone `app-bitcoin` with `git clone git@github.com:LedgerHQ/app-bitcoin.git`.
+* Open the `app-bitcoin` folder with VSCode.
 * Use Ledger extension's sidebar menu or open the tasks menu with `ctrl + shift + b` (`command + shift + b` on a Mac) to conveniently execute actions :
     * Build the app for the device model of your choice with `Build`.
     * Test your binary on [Speculos](https://github.com/LedgerHQ/speculos) with `Run with Speculos`.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This is the Bitcoin application for Ledger devices.
 
+> [!NOTE]
+> **This repository was renamed.** It was previously `LedgerHQ/app-bitcoin-new` and is
+> the current, actively developed Ledger Bitcoin application.
+>
+> The older Bitcoin app that used to live at `LedgerHQ/app-bitcoin` has been renamed to
+> [`LedgerHQ/app-bitcoin-legacy`](https://github.com/LedgerHQ/app-bitcoin-legacy).
+
 ## Quick start guide
 
 ### With VSCode

--- a/bitcoin_client/README.md
+++ b/bitcoin_client/README.md
@@ -4,7 +4,7 @@
 
 Client library for Ledger Bitcoin application.
 
-Main repository and documentation: https://github.com/LedgerHQ/app-bitcoin-new
+Main repository and documentation: https://github.com/LedgerHQ/app-bitcoin
 
 ## Install
 

--- a/bitcoin_client/ledger_bitcoin/client.py
+++ b/bitcoin_client/ledger_bitcoin/client.py
@@ -226,7 +226,7 @@ class NewClient(Client):
         first_addr_device = self.get_wallet_address(wallet, wallet_hmac, 0, 0, False)
 
         if first_addr_device != self._derive_address_for_policy(wallet, False, 0):
-            raise RuntimeError("Invalid address. Please update your Bitcoin app. If the problem persists, report a bug at https://github.com/LedgerHQ/app-bitcoin-new")
+            raise RuntimeError("Invalid address. Please update your Bitcoin app. If the problem persists, report a bug at https://github.com/LedgerHQ/app-bitcoin")
 
         return wallet_id, wallet_hmac
 
@@ -267,7 +267,7 @@ class NewClient(Client):
         # sanity check: for miniscripts, derive the address independently
 
         if result != self._derive_address_for_policy(wallet, change, address_index):
-            raise RuntimeError("Invalid address. Please update your Bitcoin app. If the problem persists, report a bug at https://github.com/LedgerHQ/app-bitcoin-new")
+            raise RuntimeError("Invalid address. Please update your Bitcoin app. If the problem persists, report a bug at https://github.com/LedgerHQ/app-bitcoin")
 
         return result
 

--- a/bitcoin_client/setup.cfg
+++ b/bitcoin_client/setup.cfg
@@ -6,9 +6,9 @@ author_email = hello@ledger.fr
 description = Client for Ledger Nano Bitcoin application
 long_description = file: README.md
 long_description_content_type = text/markdown
-url = https://github.com/LedgerHQ/app-bitcoin-new
+url = https://github.com/LedgerHQ/app-bitcoin
 project_urls =
-    Bug Tracker = https://github.com/LedgerHQ/app-bitcoin-new/issues
+    Bug Tracker = https://github.com/LedgerHQ/app-bitcoin/issues
 classifiers =
     Programming Language :: Python :: 3
     License :: OSI Approved :: Apache Software License

--- a/bitcoin_client_js/README.md
+++ b/bitcoin_client_js/README.md
@@ -4,7 +4,7 @@
 
 TypeScript client for Ledger Bitcoin application. Supports versions 2.1.0 and above of the app.
 
-Main repository and documentation: https://github.com/LedgerHQ/app-bitcoin-new
+Main repository and documentation: https://github.com/LedgerHQ/app-bitcoin
 
 ## Install
 

--- a/bitcoin_client_js/package.json
+++ b/bitcoin_client_js/package.json
@@ -7,7 +7,7 @@
   "typings": "build/main/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/LedgerHQ/app-bitcoin-new.git"
+    "url": "git+https://github.com/LedgerHQ/app-bitcoin.git"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/bitcoin_client_js/src/lib/appClient.ts
+++ b/bitcoin_client_js/src/lib/appClient.ts
@@ -68,7 +68,7 @@ function makePartialSignature(pubkeyAugm: Buffer, signature: Buffer): PartialSig
 
 /**
  * This class encapsulates the APDU protocol documented at
- * https://github.com/LedgerHQ/app-bitcoin-new/blob/master/doc/bitcoin.md
+ * https://github.com/LedgerHQ/app-bitcoin/blob/master/doc/bitcoin.md
  */
 export class AppClient {
   readonly transport: Transport;

--- a/bitcoin_client_js/src/lib/merkelizedPsbt.ts
+++ b/bitcoin_client_js/src/lib/merkelizedPsbt.ts
@@ -10,7 +10,7 @@ import { PsbtV2 } from './psbtv2';
  * so it can't always store the full psbt in memory.
  *
  * The signing process is documented at
- * https://github.com/LedgerHQ/app-bitcoin-new/blob/master/doc/bitcoin.md#sign_psbt
+ * https://github.com/LedgerHQ/app-bitcoin/blob/master/doc/bitcoin.md#sign_psbt
  */
 export class MerkelizedPsbt extends PsbtV2 {
   public readonly globalMerkleMap: MerkleMap;

--- a/bitcoin_client_js/src/lib/merkle.ts
+++ b/bitcoin_client_js/src/lib/merkle.ts
@@ -7,7 +7,7 @@ function sha256AsBuffer(buf: Buffer): Buffer {
 /**
  * This class implements the merkle tree used by Ledger Bitcoin app v2+,
  * which is documented at
- * https://github.com/LedgerHQ/app-bitcoin-new/blob/master/doc/merkle.md
+ * https://github.com/LedgerHQ/app-bitcoin/blob/master/doc/merkle.md
  */
 export class Merkle {
   private leaves: Buffer[];

--- a/bitcoin_client_js/src/lib/merkleMap.ts
+++ b/bitcoin_client_js/src/lib/merkleMap.ts
@@ -3,7 +3,7 @@ import { createVarint } from './varint';
 
 /**
  * This implements "Merkelized Maps", documented at
- * https://github.com/LedgerHQ/app-bitcoin-new/blob/master/doc/merkle.md#merkleized-maps
+ * https://github.com/LedgerHQ/app-bitcoin/blob/master/doc/merkle.md#merkleized-maps
  *
  * A merkelized map consist of two merkle trees, one for the keys of
  * a map and one for the values of the same map, thus the two merkle

--- a/bitcoin_client_js/src/lib/policy.ts
+++ b/bitcoin_client_js/src/lib/policy.ts
@@ -11,7 +11,7 @@ const WALLET_POLICY_V2 = 2;
  * of a "Descriptor Template" and a list of "keys". A key is basically
  * a serialized BIP32 extended public key with some added derivation path
  * information. This is documented at
- * https://github.com/LedgerHQ/app-bitcoin-new/blob/master/doc/wallet.md
+ * https://github.com/LedgerHQ/app-bitcoin/blob/master/doc/wallet.md
  */
 export class WalletPolicy {
   readonly name: string;

--- a/bitcoin_client_rs/Cargo.toml
+++ b/bitcoin_client_rs/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.6.2"
 authors = ["Ledger"]
 edition = "2018"
 description = "Ledger Bitcoin application client"
-repository = "https://github.com/LedgerHQ/app-bitcoin-new"
+repository = "https://github.com/LedgerHQ/app-bitcoin"
 license = "Apache-2.0"
 documentation = "https://docs.rs/ledger_bitcoin_client/"
 

--- a/bitcoin_client_rs/src/async_client.rs
+++ b/bitcoin_client_rs/src/async_client.rs
@@ -101,7 +101,7 @@ impl<T: Transport> BitcoinClient<T> {
             .script_pubkey()
             != expected_address.assume_checked_ref().script_pubkey()
         {
-            return Err(BitcoinClientError::InvalidResponse("Invalid address. Please update your Bitcoin app. If the problem persists, report a bug at https://github.com/LedgerHQ/app-bitcoin-new".to_string()));
+            return Err(BitcoinClientError::InvalidResponse("Invalid address. Please update your Bitcoin app. If the problem persists, report a bug at https://github.com/LedgerHQ/app-bitcoin".to_string()));
         }
 
         Ok(())

--- a/bitcoin_client_rs/src/client.rs
+++ b/bitcoin_client_rs/src/client.rs
@@ -96,7 +96,7 @@ impl<T: Transport> BitcoinClient<T> {
             .script_pubkey()
             != expected_address.assume_checked_ref().script_pubkey()
         {
-            return Err(BitcoinClientError::InvalidResponse("Invalid address. Please update your Bitcoin app. If the problem persists, report a bug at https://github.com/LedgerHQ/app-bitcoin-new".to_string()));
+            return Err(BitcoinClientError::InvalidResponse("Invalid address. Please update your Bitcoin app. If the problem persists, report a bug at https://github.com/LedgerHQ/app-bitcoin".to_string()));
         }
 
         Ok(())

--- a/dev-tools/playground/README.md
+++ b/dev-tools/playground/README.md
@@ -16,7 +16,7 @@ Two front-ends:
 
 ## Setup
 
-All commands assume you're at the repo root (`app-bitcoin-new/`).
+All commands assume you're at the repo root (`app-bitcoin/`).
 
 ```bash
 # 1. Create and activate a Python virtualenv (Python >= 3.8).

--- a/ragger_bitcoin/setup.cfg
+++ b/ragger_bitcoin/setup.cfg
@@ -6,9 +6,9 @@ author_email = hello@ledger.fr
 description = Ragger wrapper for Leger Bitcoin Client
 long_description = file: README.md
 long_description_content_type = text/markdown
-url = https://github.com/LedgerHQ/app-bitcoin-new
+url = https://github.com/LedgerHQ/app-bitcoin
 project_urls =
-    Bug Tracker = https://github.com/LedgerHQ/app-bitcoin-new
+    Bug Tracker = https://github.com/LedgerHQ/app-bitcoin
 classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.8


### PR DESCRIPTION
**Prerequisites**
- [x] the [app-bitcoin-new repository](https://github.com/LedgerHQ/app-bitcoin-new) rename on GitHub

Followed by [app-bitcoin-new rename to app-bitcoin - let's now use the docker image - already deployed after the push on develop](https://github.com/LedgerHQ/app-bitcoin-new/pull/514)
