### PR TITLE
enable LTO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,11 @@ ENABLE_SWAP = 1
 ENABLE_STACK_PROTECTOR = 1
 
 ########################################
+#                 LTO                  #
+########################################
+ENABLE_LINK_TIME_OPTIMIZATION = 1
+
+########################################
 #          Features disablers          #
 ########################################
 # Don't use standard app file to avoid conflicts for now


### PR DESCRIPTION
Enabling link time optimization to reduce `.text` size :

without LTO :

```
(venv) root@24b2b4bfe0db:/app# size  -A bin/app.elf
bin/app.elf  :
section                 size         addr
.text                 116633   3235774464
.data                      0   3489660928
.bss                   36864   3665428480
DEBUG                     16   3489660928
.comment                 112            0
ledger.target              4            0
ledger.target_name        11            0
ledger.target_id          10            0
ledger.app_name           12            0
ledger.app_version         5            0
ledger.api_level           2            0
ledger.sdk_name           17            0
ledger.sdk_version         7            0
ledger.sdk_hash           40            0
ledger.sdk_graphics        4            0
ledger.app_flags           5            0
.ARM.attributes           69            0
Total                 153811
```

with LTO :

```
(venv) root@24b2b4bfe0db:/app# size  -A bin/app.elf
bin/app.elf  :
section                 size         addr
.text                 109465   3235774464
.data                      0   3489660928
.bss                   36864   3665428480
DEBUG                     16   3489660928
.comment                 112            0
ledger.target              4            0
ledger.target_name        11            0
ledger.target_id          10            0
ledger.app_name           12            0
ledger.app_version         5            0
ledger.api_level           2            0
ledger.sdk_name           17            0
ledger.sdk_version         7            0
ledger.sdk_hash           40            0
ledger.sdk_graphics        4            0
ledger.app_flags           5            0
.ARM.attributes           39            0
Total                 146613
```