### PR TITLE
Fix JS tests

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install yarn
         run: |

--- a/bitcoin_client_js/package-lock.json
+++ b/bitcoin_client_js/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bitcoinerlab/descriptors": "^3.0.6",
+        "@bitcoinerlab/descriptors": "3.1.7",
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@ledgerhq/hw-transport": "^6.31.13",
         "bip32-path": "^0.4.2",
@@ -1784,23 +1784,21 @@
       "license": "MIT"
     },
     "node_modules/@bitcoinerlab/descriptors": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-3.0.6.tgz",
-      "integrity": "sha512-ofnRRCw5O+7elj8CzRtiLmCg+0j6uCxwJ7z4J5SFK1FSmVWjfmgyol3TxvNTQXzu80BYeUqL+qUW/UdKRZyjWA==",
-      "license": "MIT",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-3.1.7.tgz",
+      "integrity": "sha512-HUWXFgIeHGV5N1kf7C4KxBkYwb3H1DfyxNY4hooGCNjBKDtp4aeuIvo9PHkUi7XkmBSwFIrDWzW73CLiKY3bpA==",
       "dependencies": {
-        "@bitcoinerlab/miniscript": "^2.0.0",
+        "@bitcoinerlab/descriptors-core": "3.1.7",
         "@bitcoinerlab/secp256k1": "^1.2.0",
-        "bip174": "^3.0.0",
         "bip32": "^5.0.1",
         "bitcoinjs-lib": "^7.0.1",
-        "ecpair": "^3.0.1",
-        "lodash.memoize": "^4.1.2",
-        "uint8array-tools": "^0.0.9",
-        "varuint-bitcoin": "^2.0.0"
+        "ecpair": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@ledgerhq/ledger-bitcoin": "^0.3.0"
+        "@ledgerhq/ledger-bitcoin": "^0.3.1"
       },
       "peerDependenciesMeta": {
         "@ledgerhq/ledger-bitcoin": {
@@ -1808,11 +1806,103 @@
         }
       }
     },
+    "node_modules/@bitcoinerlab/descriptors/node_modules/@bitcoinerlab/descriptors-core": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors-core/-/descriptors-core-3.1.7.tgz",
+      "integrity": "sha512-7VccUDvKcHK7RF07Vo19Obax9jO3wlPWIXtvXy61GBqXptKv156O9Z4+sm2py1CuxPRpTXHlvH70G4KVVDoKlw==",
+      "dependencies": {
+        "@bitcoinerlab/miniscript": "^2.0.0",
+        "lodash.memoize": "^4.1.2",
+        "uint8array-tools": "^0.0.9",
+        "varuint-bitcoin": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@ledgerhq/ledger-bitcoin": "^0.3.1",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "@scure/base": "^2.0.0",
+        "@scure/bip32": "^2.0.1",
+        "@scure/btc-signer": "^2.0.1",
+        "bip32": "^5.0.1",
+        "bitcoinjs-lib": "^7.0.1",
+        "ecpair": "^3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "@ledgerhq/ledger-bitcoin": {
+          "optional": true
+        },
+        "@noble/curves": {
+          "optional": true
+        },
+        "@noble/hashes": {
+          "optional": true
+        },
+        "@scure/base": {
+          "optional": true
+        },
+        "@scure/bip32": {
+          "optional": true
+        },
+        "@scure/btc-signer": {
+          "optional": true
+        },
+        "bip32": {
+          "optional": true
+        },
+        "bitcoinjs-lib": {
+          "optional": true
+        },
+        "ecpair": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@bitcoinerlab/descriptors/node_modules/@noble/curves": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@noble/hashes": "2.4.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@bitcoinerlab/descriptors/node_modules/@noble/hashes": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@bitcoinerlab/descriptors/node_modules/@scure/base": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.4.0.tgz",
+      "integrity": "sha512-thZ1TuJwFwBblOhgsjDKvvGirBxNp+wSvY/DR6tJBJOTDhdAAcHJ8Vbr2eFnqaxeca4+t0i9KBf+uHYGWwZORg==",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@bitcoinerlab/miniscript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@bitcoinerlab/miniscript/-/miniscript-2.0.0.tgz",
       "integrity": "sha512-P8yyubPf6lphmIZfyD/ZbhT/umJX7zH1mKjGql7z0Qt+xuffnz2AueQqq2/01VE2rTIq80VM0oRFdJClGBYx/g==",
-      "license": "MIT",
       "dependencies": {
         "bip68": "^1.0.4"
       }
@@ -4359,7 +4449,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/bip68/-/bip68-1.0.4.tgz",
       "integrity": "sha512-O1htyufFTYy3EO0JkHg2CLykdXEtV2ssqw47Gq9A0WByp662xpJnMEB9m43LZjsSDjIAOozWRExlFQk2hlV1XQ==",
-      "license": "ISC",
       "engines": {
         "node": ">=4.5.0"
       }

--- a/bitcoin_client_js/package.json
+++ b/bitcoin_client_js/package.json
@@ -34,7 +34,7 @@
     "node": ">=18.14"
   },
   "dependencies": {
-    "@bitcoinerlab/descriptors": "^3.0.6",
+    "@bitcoinerlab/descriptors": "3.1.7",
     "@bitcoinerlab/secp256k1": "^1.2.0",
     "@ledgerhq/hw-transport": "^6.31.13",
     "bip32-path": "^0.4.2",


### PR DESCRIPTION
Pins `@bitcoinerlab/descriptors` to version 3.1.7, since CI broke with version 3.2.0.

Updates the `node` version in the CI to v24.