### PR TITLE
Update python dependencies, and bump minimum python version to 3.9

### DIFF
--- a/bitcoin_client/pyproject.toml
+++ b/bitcoin_client/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
-    "ledgercomm>=1.1.0",
     "setuptools>=42",
-    "typing-extensions>=3.7",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"

--- a/bitcoin_client/setup.cfg
+++ b/bitcoin_client/setup.cfg
@@ -16,9 +16,9 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.9
 install_requires=
-  typing-extensions>=3.7
+  typing-extensions>=4.16.0
   ledgercomm>=1.1.0
   packaging>=21.3
 

--- a/dev-tools/playground/requirements.txt
+++ b/dev-tools/playground/requirements.txt
@@ -2,6 +2,6 @@
 # See dev-tools/playground/README.md for full setup instructions.
 
 bip32>=3.4,<4.0        # external-cosigner xpub derivation
-mnemonic==0.20         # BIP-39 mnemonic -> seed
+mnemonic>=0.20,<0.21   # BIP-39 mnemonic -> seed
 embit>=0.7.0,<0.8.0    # used by test_utils.txmaker (fake-PSBT generator)
 textual>=0.50          # TUI front-end (dev-tools/playground/gui.py)

--- a/ragger_bitcoin/setup.cfg
+++ b/ragger_bitcoin/setup.cfg
@@ -11,7 +11,6 @@ project_urls =
     Bug Tracker = https://github.com/LedgerHQ/app-bitcoin
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     License :: OSI Approved :: Apache Software License
@@ -21,6 +20,6 @@ classifiers =
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.9
 install_requires=
-        ledger-bitcoin
+        ledger-bitcoin>=0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,9 @@ pytest-benchmark>=4.0.0,<5.0.0
 pytest-timeout>=2.1.0,<3.0.0
 ledgercomm>=1.1.0,<1.2.0
 ecdsa>=0.16.1,<0.17.0
-typing-extensions>=3.7,<4.0
+typing-extensions>=4.16.0,<5.0.0
 embit>=0.7.0,<0.8.0
-mnemonic==0.20
+mnemonic>=0.20,<0.21
 bip32>=3.4,<4.0
 speculos>=0.21.2
 ragger[speculos, ledgerwallet]>=1.37.0


### PR DESCRIPTION
The typing-extensions version being too old started creating problems in the CI; bump to a more recent version.

Some other minor cleanups are included.